### PR TITLE
Test aarch64_be-unknown-linux-gnu and riscv32gc-unknown-linux-gnu on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - rust: nightly
             target: aarch64-unknown-linux-gnu
+          - rust: nightly
+            target: aarch64_be-unknown-linux-gnu
+            os: ubuntu-18.04
           - rust: stable
             target: arm-unknown-linux-gnueabi
           - rust: nightly
@@ -87,6 +90,8 @@ jobs:
             os: ubuntu-18.04
           - rust: nightly
             target: powerpc64le-unknown-linux-gnu
+          - rust: nightly
+            target: riscv32gc-unknown-linux-gnu
           - rust: stable
             target: riscv64gc-unknown-linux-gnu
           - rust: nightly
@@ -115,26 +120,29 @@ jobs:
       - run: |
           echo "RUSTFLAGS=${RUSTFLAGS} --cfg qemu" >>"${GITHUB_ENV}"
         if: startsWith(matrix.target, 'powerpc64')
+      - run: |
+          echo "TARGET=--target ${{ matrix.target }}" >>"${GITHUB_ENV}"
+        if: matrix.target != ''
 
-      - run: cargo test -vv --workspace --all-features $DOCTEST_XCOMPILE
-      - run: cargo test -vv --workspace --all-features --release $DOCTEST_XCOMPILE
-      - run: cargo test -vv --workspace --all-features --release $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features $TARGET $BUILD_STD $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
           CARGO_PROFILE_RELEASE_LTO: fat
 
       # +cmpxchg16b
-      - run: cargo test -vv --workspace --all-features $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+cmpxchg16b
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+cmpxchg16b
         if: matrix.target == '' || startsWith(matrix.target, 'x86_64')
-      - run: cargo test -vv --workspace --all-features --release $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+cmpxchg16b
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+cmpxchg16b
         if: matrix.target == '' || startsWith(matrix.target, 'x86_64')
-      - run: cargo test -vv --workspace --all-features --release $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
           CARGO_PROFILE_RELEASE_LTO: fat
@@ -143,17 +151,17 @@ jobs:
         if: matrix.target == '' || startsWith(matrix.target, 'x86_64')
 
       # -sse2
-      - run: cargo test -vv --workspace --all-features $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=-sse2
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=-sse2
         if: startsWith(matrix.target, 'i686')
-      - run: cargo test -vv --workspace --all-features --release $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=-sse2
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=-sse2
         if: startsWith(matrix.target, 'i686')
-      - run: cargo test -vv --workspace --all-features --release $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
           CARGO_PROFILE_RELEASE_LTO: fat
@@ -162,17 +170,17 @@ jobs:
         if: startsWith(matrix.target, 'i686')
 
       # +lse
-      - run: cargo test -vv --workspace --all-features $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+lse
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+lse
         if: startsWith(matrix.target, 'aarch64')
-      - run: cargo test -vv --workspace --all-features --release $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+lse
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+lse
         if: startsWith(matrix.target, 'aarch64')
-      - run: cargo test -vv --workspace --all-features --release $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
           CARGO_PROFILE_RELEASE_LTO: fat
@@ -182,17 +190,17 @@ jobs:
       # TODO: it seems qemu-user has not yet properly implemented FEAT_LSE2: https://github.com/taiki-e/portable-atomic/pull/11#issuecomment-1114044327
 
       # pwr8
-      - run: cargo test -vv --workspace --all-features $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-cpu=pwr8
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=pwr8
         if: startsWith(matrix.target, 'powerpc64-')
-      - run: cargo test -vv --workspace --all-features --release $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-cpu=pwr8
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=pwr8
         if: startsWith(matrix.target, 'powerpc64-')
-      - run: cargo test -vv --workspace --all-features --release $DOCTEST_XCOMPILE
+      - run: cargo test -vv --workspace --all-features --release $TARGET $BUILD_STD $DOCTEST_XCOMPILE
         env:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
           CARGO_PROFILE_RELEASE_LTO: fat
@@ -200,7 +208,7 @@ jobs:
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-cpu=pwr8
         if: startsWith(matrix.target, 'powerpc64-')
 
-      - run: cargo minimal-versions build -vvv --workspace --all-features --ignore-private
+      - run: cargo minimal-versions build -vvv --workspace --all-features --ignore-private $TARGET $BUILD_STD
         if: startsWith(matrix.rust, 'nightly')
 
   build:


### PR DESCRIPTION
setup-cross-toolchain-action now supports these tier 3 targets.

https://github.com/taiki-e/setup-cross-toolchain-action/releases/tag/v1.3.0