### PR TITLE
Use MaybeUninit registers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,12 @@ jobs:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -C target-feature=+v8
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -C target-feature=+v8
         if: matrix.target == 'armv7-unknown-linux-gnueabi'
+      # arm v6 with legacy cp15_barrier
+      - run: tools/test.sh -vv --tests $TARGET $BUILD_STD $RELEASE
+        env:
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg atomic_maybe_uninit_use_cp15_barrier
+          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} --cfg atomic_maybe_uninit_use_cp15_barrier
+        if: matrix.target == 'arm-unknown-linux-gnueabi'
       # arm v7 big endian
       # armeb-unknown-linux-gnueabi is v8 by default, use custom target instead
       - run: tools/test.sh -vv --tests --target armebv7-unknown-linux-gnueabi -Z build-std $RELEASE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
             target: i686-unknown-linux-gnu
           - rust: nightly
             target: hexagon-unknown-linux-musl
+          - rust: nightly-2023-08-23 # The last nightly version that doesn't support MaybeUninit registers.
+            target: hexagon-unknown-linux-musl
           - rust: '1.72' # inline asm for loongarch has been stabilized in Rust 1.72
             target: loongarch64-unknown-linux-gnu
           - rust: stable
@@ -162,6 +164,8 @@ jobs:
           - rust: nightly-2021-12-16 # Rust 1.59, LLVM 13 (oldest version we can use asm_experimental_arch on this target)
             target: powerpc64le-unknown-linux-gnu
           - rust: nightly
+            target: riscv32gc-unknown-linux-gnu
+          - rust: nightly-2023-08-23 # The last nightly version that doesn't support MaybeUninit registers.
             target: riscv32gc-unknown-linux-gnu
           - rust: '1.59'
             target: riscv64gc-unknown-linux-gnu
@@ -292,6 +296,8 @@ jobs:
           - '1.59'
           - stable
           - beta
+          - nightly-2023-08-23 # The last nightly version that doesn't support MaybeUninit registers.
+          - nightly-2023-08-24 # The oldest nightly version that supports MaybeUninit registers: https://github.com/rust-lang/rust/pull/114790
           - nightly
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/build.rs
+++ b/build.rs
@@ -45,6 +45,10 @@ fn main() {
     if !version.probe(61, 2022, 3, 7) {
         println!("cargo:rustc-cfg=atomic_maybe_uninit_no_const_fn_trait_bound");
     }
+    // https://github.com/rust-lang/rust/pull/114790 merged in nightly-2023-08-24
+    if !version.probe(74, 2023, 8, 23) {
+        println!("cargo:rustc-cfg=atomic_maybe_uninit_no_asm_maybe_uninit");
+    }
 
     match target_arch {
         "loongarch64" => {

--- a/build.rs
+++ b/build.rs
@@ -74,8 +74,8 @@ fn main() {
         _ => {}
     }
 
-    let is_apple =
-        target_os == "macos" || target_os == "ios" || target_os == "tvos" || target_os == "watchos";
+    let is_macos = target_os == "macos";
+    let is_apple = is_macos || target_os == "ios" || target_os == "tvos" || target_os == "watchos";
     match target_arch {
         "x86_64" => {
             // x86_64 Apple targets always support CMPXCHG16B:
@@ -130,7 +130,6 @@ fn main() {
         "aarch64" => {
             // aarch64 macOS always supports FEAT_LSE/FEAT_LSE2/FEAT_LRCPC because it is armv8.5-a:
             // https://github.com/llvm/llvm-project/blob/llvmorg-17.0.0-rc2/llvm/include/llvm/TargetParser/AArch64TargetParser.h#L494
-            let is_macos = target_os == "macos";
             let mut has_lse = is_macos;
             let mut has_rcpc = is_macos;
             // FEAT_LSE2 doesn't imply FEAT_LSE. FEAT_LSE128 implies FEAT_LSE but not FEAT_LSE2. FEAT_LRCPC3 implies FEAT_LRCPC.

--- a/src/arch/avr.rs
+++ b/src/arch/avr.rs
@@ -45,15 +45,14 @@ macro_rules! atomic {
             #[inline]
             unsafe fn atomic_load(
                 src: *const MaybeUninit<Self>,
-                out: *mut MaybeUninit<Self>,
                 _order: Ordering,
-            ) {
+            ) -> MaybeUninit<Self> {
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
                     let s = disable();
-                    let v = src.read();
+                    let out = src.read();
                     restore(s);
-                    out.write(v);
+                    out
                 }
             }
         }
@@ -61,14 +60,13 @@ macro_rules! atomic {
             #[inline]
             unsafe fn atomic_store(
                 dst: *mut MaybeUninit<Self>,
-                val: *const MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
                 _order: Ordering,
             ) {
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
-                    let v = val.read();
                     let s = disable();
-                    dst.write(v);
+                    dst.write(val);
                     restore(s);
                 }
             }

--- a/src/arch/s390x.rs
+++ b/src/arch/s390x.rs
@@ -8,8 +8,8 @@
 // - portable-atomic https://github.com/taiki-e/portable-atomic
 //
 // Generated asm:
-// - s390x https://godbolt.org/z/qv8s6o13G
-// - s390x (z196) https://godbolt.org/z/jW67E4YEq
+// - s390x https://godbolt.org/z/WMa8541M5
+// - s390x (z196) https://godbolt.org/z/86d5fPhEW
 
 #[path = "partword.rs"]
 mod partword;
@@ -20,7 +20,10 @@ use core::{
     sync::atomic::Ordering,
 };
 
-use crate::raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap};
+use crate::{
+    raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap},
+    utils::{MaybeUninit128, Pair},
+};
 
 type XSize = u64;
 
@@ -46,8 +49,7 @@ macro_rules! atomic_load_store {
                 _order: Ordering,
             ) -> MaybeUninit<Self> {
                 debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
-                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
-                let out_ptr = out.as_mut_ptr();
+                let out: MaybeUninit<Self>;
 
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
@@ -55,11 +57,8 @@ macro_rules! atomic_load_store {
                     asm!(
                         // (atomic) load from src to r0
                         concat!("l", $l_suffix, " %r0, 0({src})"),
-                        // store r0 to out
-                        concat!("st", $asm_suffix, " %r0, 0({out})"),
                         src = in(reg) ptr_reg!(src),
-                        out = in(reg) ptr_reg!(out_ptr),
-                        out("r0") _,
+                        out("r0") out,
                         options(nostack, preserves_flags),
                     );
                 }
@@ -74,21 +73,17 @@ macro_rules! atomic_load_store {
                 order: Ordering,
             ) {
                 debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
-                let val = val.as_ptr();
 
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
                     macro_rules! atomic_store {
                         ($fence:tt) => {
                             asm!(
-                                // load from val to r0
-                                concat!("l", $l_suffix, " %r0, 0({val})"),
                                 // (atomic) store r0 to dst
                                 concat!("st", $asm_suffix, " %r0, 0({dst})"),
                                 $fence,
                                 dst = in(reg) ptr_reg!(dst),
-                                val = in(reg) ptr_reg!(val),
-                                out("r0") _,
+                                in("r0") val,
                                 options(nostack, preserves_flags),
                             )
                         };
@@ -126,28 +121,20 @@ macro_rules! atomic {
                 _order: Ordering,
             ) -> MaybeUninit<Self> {
                 debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
-                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
-                let out_ptr = out.as_mut_ptr();
-                let val = val.as_ptr();
+                let mut out: MaybeUninit<Self>;
 
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
                     // atomic swap is always SeqCst.
                     asm!(
-                        // load from val to val_tmp
-                        concat!("l", $asm_suffix, " {val_tmp}, 0({val})"),
                         // (atomic) swap (CAS loop)
                         concat!("l", $asm_suffix, " %r0, 0({dst})"),
                         "2:",
-                            concat!("cs", $asm_suffix, " %r0, {val_tmp}, 0({dst})"),
+                            concat!("cs", $asm_suffix, " %r0, {val}, 0({dst})"),
                             "jl 2b",
-                        // store r0 to out
-                        concat!("st", $asm_suffix, " %r0, 0({out})"),
                         dst = in(reg) ptr_reg!(dst),
-                        val = in(reg) ptr_reg!(val),
-                        val_tmp = out(reg) _,
-                        out = in(reg) ptr_reg!(out_ptr),
-                        out("r0") _,
+                        val = in(reg) val,
+                        out("r0") out,
                         // Do not use `preserves_flags` because CS modifies the condition code.
                         options(nostack),
                     );
@@ -165,31 +152,21 @@ macro_rules! atomic {
                 _failure: Ordering,
             ) -> (MaybeUninit<Self>, bool) {
                 debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
-                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
-                let out_ptr = out.as_mut_ptr();
-                let old = old.as_ptr();
-                let new = new.as_ptr();
+                let out: MaybeUninit<Self>;
 
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
                     let mut r: i64;
                     // compare_exchange is always SeqCst.
                     asm!(
-                        // load from old/new to r0/tmp
-                        concat!("l", $asm_suffix, " %r0, 0({old})"),
-                        concat!("l", $asm_suffix, " {tmp}, 0({new})"),
                         // (atomic) CAS
-                        concat!("cs", $asm_suffix, " %r0, {tmp}, 0({dst})"),
+                        concat!("cs", $asm_suffix, " %r0, {new}, 0({dst})"),
                         // store condition code
-                        "ipm {tmp}",
-                        // store r0 to out
-                        concat!("st", $asm_suffix, " %r0, 0({out})"),
+                        "ipm {r}",
                         dst = in(reg) ptr_reg!(dst),
-                        old = in(reg) ptr_reg!(old),
-                        new = in(reg) ptr_reg!(new),
-                        tmp = out(reg) r,
-                        out = in(reg) ptr_reg!(out_ptr),
-                        out("r0") _,
+                        new = in(reg) new,
+                        r = lateout(reg) r,
+                        inout("r0") old => out,
                         // Do not use `preserves_flags` because CS modifies the condition code.
                         options(nostack),
                     );
@@ -212,9 +189,7 @@ macro_rules! atomic_sub_word {
             ) -> MaybeUninit<Self> {
                 debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
                 let (aligned_ptr, shift, _mask) = partword::create_mask_values(dst);
-                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
-                let out_ptr = out.as_mut_ptr();
-                let val = val.as_ptr();
+                let mut out: MaybeUninit<Self>;
 
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
@@ -222,23 +197,21 @@ macro_rules! atomic_sub_word {
                     // Based on assemblies generated by rustc/LLVM.
                     // See also partword.rs.
                     asm!(
-                        concat!("l", $l_suffix, " %r0, 0(%r3)"),
-                        "l %r3, 0({dst})",
+                        "l %r0, 0({dst})",
                         "2:",
-                            "rll %r14, %r3, 0({shift})",
-                            concat!("risbg %r14, %r0, 32, ", $risbg_swap),
-                            "rll %r14, %r14, 0({shift_c})",
-                            "cs %r3, %r14, 0({dst})",
+                            "rll {tmp}, %r0, 0({shift})",
+                            concat!("risbg {tmp}, {val}, 32, ", $risbg_swap),
+                            "rll {tmp}, {tmp}, 0({shift_c})",
+                            "cs %r0, {tmp}, 0({dst})",
                             "jl 2b",
-                        concat!("rll %r0, %r3, ", $bits ,"({shift})"),
-                        concat!("st", $asm_suffix, " %r0, 0({out})"),
+                        concat!("rll {out}, %r0, ", $bits ,"({shift})"),
                         dst = in(reg) ptr_reg!(aligned_ptr),
-                        out = in(reg) ptr_reg!(out_ptr),
+                        val = in(reg) val,
+                        out = lateout(reg) out,
                         shift = in(reg) shift as u32,
                         shift_c = in(reg) complement(shift as u32),
-                        out("r0") _,
-                        inout("r3") ptr_reg!(val) => _,
-                        out("r14") _,
+                        tmp = out(reg) _,
+                        out("r0") _, // prev
                         // Do not use `preserves_flags` because CS modifies the condition code.
                         options(nostack),
                     );
@@ -257,10 +230,7 @@ macro_rules! atomic_sub_word {
             ) -> (MaybeUninit<Self>, bool) {
                 debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
                 let (aligned_ptr, shift, _mask) = partword::create_mask_values(dst);
-                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
-                let out_ptr = out.as_mut_ptr();
-                let old = old.as_ptr();
-                let new = new.as_ptr();
+                let mut out: MaybeUninit<Self>;
 
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
@@ -269,31 +239,28 @@ macro_rules! atomic_sub_word {
                     // Based on assemblies generated by rustc/LLVM.
                     // See also partword.rs.
                     asm!(
-                        concat!("ll", $asm_suffix, " %r0, 0(%r3)"),
-                        concat!("l", $l_suffix, " %r1, 0(%r4)"),
-                        "l %r4, 0({dst})",
+                        "l {prev}, 0({dst})",
                         "2:",
-                            concat!("rll %r13, %r4, ", $bits ,"({shift})"),
-                            concat!("risbg %r1, %r13, 32, ", $risbg_cas, ", 0"),
-                            concat!("ll", $asm_suffix, "r %r13, %r13"),
-                            "cr %r13, %r0",
+                            concat!("rll %r0, {prev}, ", $bits ,"({shift})"),
+                            concat!("risbg {new}, %r0, 32, ", $risbg_cas, ", 0"),
+                            concat!("ll", $asm_suffix, "r %r0, %r0"),
+                            "cr %r0, {old}",
                             "jlh 3f",
-                            concat!("rll %r3, %r1, -", $bits ,"({shift_c})"),
-                            "cs %r4, %r3, 0({dst})",
+                            concat!("rll {tmp}, {new}, -", $bits ,"({shift_c})"),
+                            "cs {prev}, {tmp}, 0({dst})",
                             "jl 2b",
                         "3:",
                         // store condition code
-                        "ipm %r0",
-                        concat!("st", $asm_suffix, " %r13, 0({out})"),
+                        "ipm {r}",
                         dst = in(reg) ptr_reg!(aligned_ptr),
-                        out = in(reg) ptr_reg!(out_ptr),
+                        prev = out(reg) _,
+                        old = in(reg) crate::utils::zero_extend(old),
+                        new = inout(reg) new => _,
                         shift = in(reg) shift as u32,
                         shift_c = in(reg) complement(shift as u32),
-                        out("r0") r,
-                        out("r1") _,
-                        inout("r3") ptr_reg!(old) => _,
-                        inout("r4") ptr_reg!(new) => _,
-                        out("r13") _,
+                        tmp = out(reg) _,
+                        r = lateout(reg) r,
+                        out("r0") out,
                         // Do not use `preserves_flags` because CS modifies the condition code.
                         options(nostack),
                     );
@@ -325,8 +292,7 @@ macro_rules! atomic128 {
                 _order: Ordering,
             ) -> MaybeUninit<Self> {
                 debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
-                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
-                let out_ptr = out.as_mut_ptr();
+                let (prev_hi, prev_lo);
 
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
@@ -334,18 +300,14 @@ macro_rules! atomic128 {
                     asm!(
                         // (atomic) load from src to out pair
                         "lpq %r0, 0({src})",
-                        // store out pair to out
-                        "stg %r1, 8({out})",
-                        "stg %r0, 0({out})",
                         src = in(reg) ptr_reg!(src),
-                        out = in(reg) ptr_reg!(out_ptr),
                         // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
-                        out("r0") _, // out (hi)
-                        out("r1") _, // out (lo)
+                        out("r0") prev_hi,
+                        out("r1") prev_lo,
                         options(nostack, preserves_flags),
                     );
+                    MaybeUninit128 { pair: Pair { lo: prev_lo, hi: prev_hi } }.$int_type
                 }
-                out
             }
         }
         impl AtomicStore for $int_type {
@@ -356,24 +318,20 @@ macro_rules! atomic128 {
                 order: Ordering,
             ) {
                 debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
-                let val = val.as_ptr();
+                let val = MaybeUninit128 { $int_type: val };
 
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
                     macro_rules! atomic_store {
                         ($fence:tt) => {
                             asm!(
-                                // load from val to val pair
-                                "lg %r1, 8({val})",
-                                "lg %r0, 0({val})",
                                 // (atomic) store val pair to dst
                                 "stpq %r0, 0({dst})",
                                 $fence,
                                 dst = in(reg) ptr_reg!(dst),
-                                val = in(reg) ptr_reg!(val),
                                 // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
-                                out("r0") _, // val (hi)
-                                out("r1") _, // val (lo)
+                                in("r0") val.pair.hi,
+                                in("r1") val.pair.lo,
                                 options(nostack, preserves_flags),
                             )
                         };
@@ -405,38 +363,29 @@ macro_rules! atomic128 {
                 _order: Ordering,
             ) -> MaybeUninit<Self> {
                 debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
-                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
-                let out_ptr = out.as_mut_ptr();
-                let val = val.as_ptr();
+                let val = MaybeUninit128 { $int_type: val };
+                let (mut prev_hi, mut prev_lo);
 
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
                     // atomic swap is always SeqCst.
                     asm!(
-                        // load from val to val pair
-                        "lg %r1, 8({val})",
-                        "lg %r0, 0({val})",
                         // (atomic) swap (CAS loop)
-                        "lpq %r2, 0({dst})",
+                        "lpq %r0, 0({dst})",
                         "2:",
-                            "cdsg %r2, %r0, 0({dst})",
+                            "cdsg %r0, %r12, 0({dst})",
                             "jl 2b",
-                        // store out pair to out
-                        "stg %r3, 8({out})",
-                        "stg %r2, 0({out})",
                         dst = inout(reg) ptr_reg!(dst) => _,
-                        val = in(reg) ptr_reg!(val),
-                        out = inout(reg) ptr_reg!(out_ptr) => _,
                         // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
-                        out("r0") _, // val (hi)
-                        out("r1") _, // val (lo)
-                        lateout("r2") _, // out (hi)
-                        lateout("r3") _, // out (lo)
+                        out("r0") prev_hi,
+                        out("r1") prev_lo,
+                        in("r12") val.pair.hi,
+                        in("r13") val.pair.lo,
                         // Do not use `preserves_flags` because CDSG modifies the condition code.
                         options(nostack),
                     );
+                    MaybeUninit128 { pair: Pair { lo: prev_lo, hi: prev_hi } }.$int_type
                 }
-                out
             }
         }
         impl AtomicCompareExchange for $int_type {
@@ -449,42 +398,33 @@ macro_rules! atomic128 {
                 _failure: Ordering,
             ) -> (MaybeUninit<Self>, bool) {
                 debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
-                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
-                let out_ptr = out.as_mut_ptr();
-                let old = old.as_ptr();
-                let new = new.as_ptr();
+                let old = MaybeUninit128 { $int_type: old };
+                let new = MaybeUninit128 { $int_type: new };
+                let (prev_hi, prev_lo);
 
                 // SAFETY: the caller must uphold the safety contract.
                 unsafe {
                     let mut r: i64;
                     // compare_exchange is always SeqCst.
                     asm!(
-                        // load from old/new to old/new pairs
-                        "lg %r1, 8({old})",
-                        "lg %r0, 0({old})",
-                        "lg %r13, 8({new})",
-                        "lg %r12, 0({new})",
                         // (atomic) CAS
                         "cdsg %r0, %r12, 0({dst})",
                         // store condition code
                         "ipm {r}",
-                        // store out pair to out
-                        "stg %r1, 8({out})",
-                        "stg %r0, 0({out})",
                         dst = in(reg) ptr_reg!(dst),
-                        old = in(reg) ptr_reg!(old),
-                        new = in(reg) ptr_reg!(new),
-                        out = inout(reg) ptr_reg!(out_ptr) => _,
                         r = lateout(reg) r,
                         // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
-                        out("r0") _, // old (hi) -> out (hi)
-                        out("r1") _, // old (lo) -> out (lo)
-                        out("r12") _, // new (hi)
-                        out("r13") _, // new (hi)
+                        inout("r0") old.pair.hi => prev_hi,
+                        inout("r1") old.pair.lo => prev_lo,
+                        in("r12") new.pair.hi,
+                        in("r13") new.pair.lo,
                         // Do not use `preserves_flags` because CDSG modifies the condition code.
                         options(nostack),
                     );
-                    (out, extract_cc(r))
+                    (
+                        MaybeUninit128 { pair: Pair { lo: prev_lo, hi: prev_hi } }.$int_type,
+                        extract_cc(r)
+                    )
                 }
             }
         }

--- a/src/arch_legacy/aarch64.rs
+++ b/src/arch_legacy/aarch64.rs
@@ -1,0 +1,894 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// AArch64
+//
+// Refs:
+// - ARM Compiler armasm User Guide
+//   https://developer.arm.com/documentation/dui0801/latest
+// - Arm A-profile A64 Instruction Set Architecture
+//   https://developer.arm.com/documentation/ddi0602/latest
+// - Arm Architecture Reference Manual for A-profile architecture
+//   https://developer.arm.com/documentation/ddi0487/latest
+// - Arm Architecture Reference Manual Supplement - Armv8, for Armv8-R AArch64 architecture profile
+//   https://developer.arm.com/documentation/ddi0600/latest
+// - portable-atomic https://github.com/taiki-e/portable-atomic
+//
+// Generated asm:
+// - aarch64 https://godbolt.org/z/6TKofhrbb
+// - aarch64 msvc https://godbolt.org/z/5GzETjcE7
+// - aarch64 (+lse) https://godbolt.org/z/7jK5vej7b
+// - aarch64 msvc (+lse) https://godbolt.org/z/896zWazdW
+// - aarch64 (+lse,+lse2) https://godbolt.org/z/66cMd4Ys6
+// - aarch64 (+lse,+lse2,+rcpc3) https://godbolt.org/z/ojbaYn9Kf
+// - aarch64 (+rcpc) https://godbolt.org/z/4ahePW8TK
+// - aarch64 (+lse2,+lse128) https://godbolt.org/z/joMq5vv1h
+// - aarch64 (+lse2,+lse128,+rcpc3) https://godbolt.org/z/WdbsccKcz
+
+use core::{
+    arch::asm,
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+use crate::raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap};
+
+macro_rules! atomic_rmw {
+    ($op:ident, $order:ident) => {
+        atomic_rmw!($op, $order, write = $order)
+    };
+    ($op:ident, $order:ident, write = $write:ident) => {
+        match $order {
+            Ordering::Relaxed => $op!("", "", ""),
+            Ordering::Acquire => $op!("a", "", ""),
+            Ordering::Release => $op!("", "l", ""),
+            Ordering::AcqRel => $op!("a", "l", ""),
+            // In MSVC environments, SeqCst stores/writes needs fences after writes.
+            // https://reviews.llvm.org/D141748
+            #[cfg(target_env = "msvc")]
+            Ordering::SeqCst if $write == Ordering::SeqCst => $op!("a", "l", "dmb ish"),
+            // AcqRel and SeqCst RMWs are equivalent in non-MSVC environments.
+            Ordering::SeqCst => $op!("a", "l", ""),
+            _ => unreachable!("{:?}", $order),
+        }
+    };
+}
+
+macro_rules! atomic {
+    ($int_type:ident, $asm_suffix:tt, $val_modifier:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load {
+                        ($acquire:tt) => {
+                            asm!(
+                                // (atomic) load from src to tmp
+                                concat!("ld", $acquire, "r", $asm_suffix, " {tmp", $val_modifier, "}, [{src}]"),
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp", $val_modifier, "}, [{out}]"),
+                                src = in(reg) ptr_reg!(src),
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!(""),
+                        #[cfg(any(target_feature = "rcpc", atomic_maybe_uninit_target_feature = "rcpc"))]
+                        Ordering::Acquire => {
+                            // SAFETY: cfg guarantee that the CPU supports FEAT_LRCPC.
+                            asm!(
+                                // (atomic) load from src to tmp
+                                concat!("ldapr", $asm_suffix, " {tmp", $val_modifier, "}, [{src}]"),
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp", $val_modifier, "}, [{out}]"),
+                                src = in(reg) ptr_reg!(src),
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            );
+                        }
+                        #[cfg(not(any(target_feature = "rcpc", atomic_maybe_uninit_target_feature = "rcpc")))]
+                        Ordering::Acquire => atomic_load!("a"),
+                        Ordering::SeqCst => atomic_load!("a"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($release:tt, $fence:tt) => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("ldr", $asm_suffix, " {tmp", $val_modifier, "}, [{val}]"),
+                                // (atomic) store tmp to dst
+                                concat!("st", $release, "r", $asm_suffix, " {tmp", $val_modifier, "}, [{dst}]"),
+                                $fence,
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                val = in(reg) ptr_reg!(val),
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_store!("", ""),
+                        Ordering::Release => atomic_store!("l", ""),
+                        // AcqRel and SeqCst RMWs are equivalent in non-MSVC environments.
+                        #[cfg(not(target_env = "msvc"))]
+                        Ordering::SeqCst => atomic_store!("l", ""),
+                        // In MSVC environments, SeqCst stores/writes needs fences after writes.
+                        // https://reviews.llvm.org/D141748
+                        #[cfg(target_env = "msvc")]
+                        Ordering::SeqCst => atomic_store!("l", "dmb ish"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    #[cfg(any(target_feature = "lse", atomic_maybe_uninit_target_feature = "lse"))]
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt, $fence:tt) => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("ldr", $asm_suffix, " {tmp", $val_modifier, "}, [{val}]"),
+                                // (atomic) swap
+                                // Refs: https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/SWPA--SWPAL--SWP--SWPL--SWPAL--SWP--SWPL
+                                concat!("swp", $acquire, $release, $asm_suffix, " {tmp", $val_modifier, "}, {tmp", $val_modifier, "}, [{dst}]"),
+                                $fence,
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp", $val_modifier, "}, [{out}]"),
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                val = in(reg) ptr_reg!(val),
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    #[cfg(not(any(target_feature = "lse", atomic_maybe_uninit_target_feature = "lse")))]
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt, $fence:tt) => {
+                            asm!(
+                                // load from val to val_tmp
+                                concat!("ldr", $asm_suffix, " {val_tmp", $val_modifier, "}, [{val}]"),
+                                // (atomic) swap (LL/SC loop)
+                                "2:",
+                                    // load from dst to out_tmp
+                                    concat!("ld", $acquire, "xr", $asm_suffix, " {out_tmp", $val_modifier, "}, [{dst}]"),
+                                    // try to store val to dst
+                                    concat!("st", $release, "xr", $asm_suffix, " {r:w}, {val_tmp", $val_modifier, "}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cbnz {r:w}, 2b",
+                                $fence,
+                                // store out_tmp to out
+                                concat!("str", $asm_suffix, " {out_tmp", $val_modifier, "}, [{out}]"),
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                val = in(reg) ptr_reg!(val),
+                                val_tmp = out(reg) _,
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                out_tmp = out(reg) _,
+                                r = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32;
+                    #[cfg(any(target_feature = "lse", atomic_maybe_uninit_target_feature = "lse"))]
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt, $fence:tt) => {{
+                            asm!(
+                                // load from old/new to old_tmp/new_tmp
+                                concat!("ldr", $asm_suffix, " {old_tmp", $val_modifier, "}, [{old}]"),
+                                concat!("ldr", $asm_suffix, " {new_tmp", $val_modifier, "}, [{new}]"),
+                                // cas writes the current value to the first register,
+                                // so copy the `old`'s value for later comparison.
+                                concat!("mov {out_tmp", $val_modifier, "}, {old_tmp", $val_modifier, "}"),
+                                // (atomic) CAS
+                                // Refs: https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/CASA--CASAL--CAS--CASL--CASAL--CAS--CASL
+                                concat!("cas", $acquire, $release, $asm_suffix, " {out_tmp", $val_modifier, "}, {new_tmp", $val_modifier, "}, [{dst}]"),
+                                $fence,
+                                concat!("cmp {out_tmp", $val_modifier, "}, {old_tmp", $val_modifier, "}"),
+                                // store out_tmp to out
+                                concat!("str", $asm_suffix, " {out_tmp", $val_modifier, "}, [{out}]"),
+                                "cset {r:w}, eq",
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                old = in(reg) ptr_reg!(old),
+                                old_tmp = out(reg) _,
+                                new = in(reg) ptr_reg!(new),
+                                new_tmp = out(reg) _,
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                out_tmp = out(reg) _,
+                                r = lateout(reg) r,
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                            );
+                            debug_assert!(r == 0 || r == 1, "r={}", r);
+                            (out, r != 0)
+                        }};
+                    }
+                    #[cfg(not(any(target_feature = "lse", atomic_maybe_uninit_target_feature = "lse")))]
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt, $fence:tt) => {{
+                            asm!(
+                                // load from old/new to old_tmp/new_tmp
+                                concat!("ldr", $asm_suffix, " {new_tmp", $val_modifier, "}, [{new}]"),
+                                concat!("ldr", $asm_suffix, " {old_tmp", $val_modifier, "}, [{old}]"),
+                                // (atomic) CAS (LL/SC loop)
+                                "2:",
+                                    concat!("ld", $acquire, "xr", $asm_suffix, " {out_tmp", $val_modifier, "}, [{dst}]"),
+                                    concat!("cmp {out_tmp", $val_modifier, "}, {old_tmp", $val_modifier, "}"),
+                                    "b.ne 3f", // jump if compare failed
+                                    concat!("st", $release, "xr", $asm_suffix, " {r:w}, {new_tmp", $val_modifier, "}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cbnz {r:w}, 2b", // continue loop if store failed
+                                    $fence,
+                                    "b 4f",
+                                "3:",
+                                    "mov {r:w}, #1", // mark as failed
+                                    "clrex",
+                                "4:",
+                                // store out_tmp to out
+                                concat!("str", $asm_suffix, " {out_tmp", $val_modifier, "}, [{out}]"),
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                old = in(reg) ptr_reg!(old),
+                                old_tmp = out(reg) _,
+                                new = in(reg) ptr_reg!(new),
+                                new_tmp = out(reg) _,
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                out_tmp = out(reg) _,
+                                r = lateout(reg) r,
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                            );
+                            debug_assert!(r == 0 || r == 1, "r={}", r);
+                            // 0 if the store was successful, 1 if no store was performed
+                            (out, r == 0)
+                        }};
+                    }
+                    atomic_rmw!(cmpxchg, order, write = success)
+                }
+            }
+            #[cfg(not(any(target_feature = "lse", atomic_maybe_uninit_target_feature = "lse")))]
+            #[inline]
+            unsafe fn atomic_compare_exchange_weak(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let r: i32;
+                    macro_rules! cmpxchg_weak {
+                        ($acquire:tt, $release:tt, $fence:tt) => {
+                            asm!(
+                                // load from old/new to old_tmp/new_tmp
+                                concat!("ldr", $asm_suffix, " {new_tmp", $val_modifier, "}, [{new}]"),
+                                concat!("ldr", $asm_suffix, " {old_tmp", $val_modifier, "}, [{old}]"),
+                                // (atomic) CAS
+                                concat!("ld", $acquire, "xr", $asm_suffix, " {out_tmp", $val_modifier, "}, [{dst}]"),
+                                concat!("cmp {out_tmp", $val_modifier, "}, {old_tmp", $val_modifier, "}"),
+                                "b.ne 3f",
+                                concat!("st", $release, "xr", $asm_suffix, " {r:w}, {new_tmp", $val_modifier, "}, [{dst}]"),
+                                // TODO: only emit when the above sc succeed
+                                // // 0 if the store was successful, 1 if no store was performed
+                                // "cbnz {r:w}, 4f",
+                                $fence,
+                                "b 4f",
+                                "3:",
+                                    "mov {r:w}, #1",
+                                    "clrex",
+                                "4:",
+                                // store out_tmp to out
+                                concat!("str", $asm_suffix, " {out_tmp", $val_modifier, "}, [{out}]"),
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                old = in(reg) ptr_reg!(old),
+                                old_tmp = out(reg) _,
+                                new = in(reg) ptr_reg!(new),
+                                new_tmp = out(reg) _,
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                out_tmp = out(reg) _,
+                                r = lateout(reg) r,
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg_weak, order, write = success);
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+        }
+    };
+}
+
+atomic!(i8, "b", ":w");
+atomic!(u8, "b", ":w");
+atomic!(i16, "h", ":w");
+atomic!(u16, "h", ":w");
+atomic!(i32, "", ":w");
+atomic!(u32, "", ":w");
+atomic!(i64, "", "");
+atomic!(u64, "", "");
+#[cfg(target_pointer_width = "32")]
+atomic!(isize, "", ":w");
+#[cfg(target_pointer_width = "32")]
+atomic!(usize, "", ":w");
+#[cfg(target_pointer_width = "64")]
+atomic!(isize, "", "");
+#[cfg(target_pointer_width = "64")]
+atomic!(usize, "", "");
+
+// There are a few ways to implement 128-bit atomic operations in AArch64.
+//
+// - LDXP/STXP loop (DW LL/SC)
+// - CASP (DWCAS) added as FEAT_LSE (mandatory from armv8.1-a)
+// - LDP/STP (DW load/store) if FEAT_LSE2 (optional from armv8.2-a, mandatory from armv8.4-a) is available
+// - LDIAPP/STILP (DW acquire-load/release-store) added as FEAT_LRCPC3 (optional from armv8.9-a/armv9.4-a) (if FEAT_LSE2 is also available)
+// - LDCLRP/LDSETP/SWPP (DW RMW) added as FEAT_LSE128 (optional from armv9.4-a)
+//
+// If FEAT_LSE is available at compile-time, we use CASP for load/CAS. Otherwise, use LDXP/STXP loop.
+// If FEAT_LSE2 is available at compile-time, we use LDP/STP for load/store.
+// If FEAT_LSE128 is available at compile-time, we use SWPP for swap/{release,seqcst}-store.
+// If FEAT_LSE2 and FEAT_LRCPC3 are available at compile-time, we use LDIAPP/STILP for acquire-load/release-store.
+//
+// Note: FEAT_LSE2 doesn't imply FEAT_LSE. FEAT_LSE128 implies FEAT_LSE but not FEAT_LSE2.
+//
+// Refs:
+// - LDP: https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/LDP
+// - LDXP: https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/LDXP
+// - LDAXP: https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/LDAXP
+// - STP: https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/STP
+// - STXP: https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/STXP
+// - STLXP: https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/STLXP
+//
+// Note: Load-Exclusive pair (by itself) does not guarantee atomicity; to complete an atomic
+// operation (even load/store), a corresponding Store-Exclusive pair must succeed.
+// See Arm Architecture Reference Manual for A-profile architecture
+// Section B2.2.1 "Requirements for single-copy atomicity", and
+// Section B2.9 "Synchronization and semaphores" for more.
+macro_rules! atomic128 {
+    ($int_type:ident) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                #[cfg(any(target_feature = "lse2", atomic_maybe_uninit_target_feature = "lse2"))]
+                // SAFETY: the caller must guarantee that `dst` is valid for reads,
+                // 16-byte aligned, that there are no concurrent non-atomic operations.
+                // the above cfg guarantee that the CPU supports FEAT_LSE2.
+                unsafe {
+                    macro_rules! atomic_load_relaxed {
+                        ($acquire:tt) => {
+                            asm!(
+                                // (atomic) load from src to tmp pair
+                                "ldp {tmp_lo}, {tmp_hi}, [{src}]",
+                                $acquire,
+                                // store tmp pair to out
+                                "stp {tmp_lo}, {tmp_hi}, [{out}]",
+                                src = in(reg) ptr_reg!(src),
+                                out = in(reg) ptr_reg!(out_ptr),
+                                tmp_hi = out(reg) _,
+                                tmp_lo = out(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load_relaxed!(""),
+                        #[cfg(any(target_feature = "rcpc3", atomic_maybe_uninit_target_feature = "rcpc3"))]
+                        Ordering::Acquire => {
+                            // SAFETY: cfg guarantee that the CPU supports FEAT_LRCPC3.
+                            // Refs: https://developer.arm.com/documentation/ddi0602/2023-03/Base-Instructions/LDIAPP--Load-Acquire-RCpc-ordered-Pair-of-registers-
+                            asm!(
+                                // (atomic) load from src to tmp pair
+                                "ldiapp {tmp_lo}, {tmp_hi}, [{src}]",
+                                // store tmp pair to out
+                                "stp {tmp_lo}, {tmp_hi}, [{out}]",
+                                src = in(reg) ptr_reg!(src),
+                                out = in(reg) ptr_reg!(out_ptr),
+                                tmp_hi = out(reg) _,
+                                tmp_lo = out(reg) _,
+                                options(nostack, preserves_flags),
+                            );
+                        }
+                        #[cfg(not(any(target_feature = "rcpc3", atomic_maybe_uninit_target_feature = "rcpc3")))]
+                        Ordering::Acquire => atomic_load_relaxed!("dmb ishld"),
+                        Ordering::SeqCst => {
+                            asm!(
+                                // ldar (or dmb ishld) is required to prevent reordering with preceding stlxp.
+                                // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108891
+                                "ldar {tmp}, [{src}]",
+                                // (atomic) load from src to tmp pair
+                                "ldp {tmp_lo}, {tmp_hi}, [{src}]",
+                                "dmb ishld",
+                                // store tmp pair to out
+                                "stp {tmp_lo}, {tmp_hi}, [{out}]",
+                                src = in(reg) ptr_reg!(src),
+                                out = in(reg) ptr_reg!(out_ptr),
+                                tmp_hi = out(reg) _,
+                                tmp_lo = out(reg) _,
+                                tmp = out(reg) _,
+                                options(nostack, preserves_flags),
+                            );
+                        },
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                #[cfg(not(any(target_feature = "lse2", atomic_maybe_uninit_target_feature = "lse2")))]
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    #[cfg(any(target_feature = "lse", atomic_maybe_uninit_target_feature = "lse"))]
+                    macro_rules! atomic_load {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // (atomic) load (CAS)
+                                // Refs:
+                                // - https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/CASPA--CASPAL--CASP--CASPL--CASPAL--CASP--CASPL
+                                // - https://github.com/taiki-e/portable-atomic/pull/20
+                                concat!("casp", $acquire, $release, " x2, x3, x2, x3, [{src}]"),
+                                // store out pair to out
+                                "stp x2, x3, [{out}]",
+                                src = in(reg) ptr_reg!(src),
+                                out = in(reg) ptr_reg!(out_ptr),
+                                // must be allocated to even/odd register pair
+                                inout("x2") 0_u64 => _, // out_lo
+                                inout("x3") 0_u64 => _, // out_lo
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    #[cfg(not(any(target_feature = "lse", atomic_maybe_uninit_target_feature = "lse")))]
+                    macro_rules! atomic_load {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // (atomic) load from src to tmp pair
+                                "2:",
+                                    // load from src to tmp pair
+                                    concat!("ld", $acquire, "xp {tmp_lo}, {tmp_hi}, [{src}]"),
+                                    // store tmp pair to src
+                                    concat!("st", $release, "xp {r:w}, {tmp_lo}, {tmp_hi}, [{src}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cbnz {r:w}, 2b",
+                                // store tmp pair to out
+                                "stp {tmp_lo}, {tmp_hi}, [{out}]",
+                                src = in(reg) ptr_reg!(src),
+                                out = in(reg) ptr_reg!(out_ptr),
+                                tmp_hi = out(reg) _,
+                                tmp_lo = out(reg) _,
+                                r = out(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!("", ""),
+                        Ordering::Acquire => atomic_load!("a", ""),
+                        Ordering::SeqCst => atomic_load!("a", "l"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                #[cfg(any(target_feature = "lse2", atomic_maybe_uninit_target_feature = "lse2"))]
+                // SAFETY: the caller must guarantee that `dst` is valid for writes,
+                // 16-byte aligned, that there are no concurrent non-atomic operations.
+                // the above cfg guarantee that the CPU supports FEAT_LSE2.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from val to val pair
+                                "ldp {val_lo}, {val_hi}, [{val}]",
+                                // (atomic) store val pair to dst
+                                $release,
+                                "stp {val_lo}, {val_hi}, [{dst}]",
+                                $acquire,
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(reg) ptr_reg!(val),
+                                val_hi = out(reg) _,
+                                val_lo = out(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    // Use swpp if stp requires fences.
+                    // https://reviews.llvm.org/D143506
+                    #[cfg(any(target_feature = "lse128", atomic_maybe_uninit_target_feature = "lse128"))]
+                    macro_rules! atomic_store_swpp {
+                        ($acquire:tt, $release:tt, $fence:tt) => {
+                            asm!(
+                                // load from val to val pair
+                                "ldp {val_lo}, {val_hi}, [{val}]",
+                                // (atomic) swap
+                                concat!("swpp", $acquire, $release, " {val_lo}, {val_hi}, [{dst}]"),
+                                $fence,
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(reg) ptr_reg!(val),
+                                val_hi = out(reg) _,
+                                val_lo = out(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_store!("", ""),
+                        #[cfg(any(target_feature = "rcpc3", atomic_maybe_uninit_target_feature = "rcpc3"))]
+                        Ordering::Release => {
+                            // SAFETY: cfg guarantee that the CPU supports FEAT_LRCPC3.
+                            // Refs: https://developer.arm.com/documentation/ddi0602/2023-03/Base-Instructions/STILP--Store-Release-ordered-Pair-of-registers-
+                            asm!(
+                                // load from val to val pair
+                                "ldp {val_lo}, {val_hi}, [{val}]",
+                                // (atomic) store val pair to dst
+                                "stilp {val_lo}, {val_hi}, [{dst}]",
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(reg) ptr_reg!(val),
+                                val_hi = out(reg) _,
+                                val_lo = out(reg) _,
+                                options(nostack, preserves_flags),
+                            );
+                        }
+                        #[cfg(any(target_feature = "lse128", atomic_maybe_uninit_target_feature = "lse128"))]
+                        #[cfg(not(any(target_feature = "rcpc3", atomic_maybe_uninit_target_feature = "rcpc3")))]
+                        Ordering::Release => atomic_rmw!(atomic_store_swpp, order),
+                        #[cfg(not(any(target_feature = "lse128", atomic_maybe_uninit_target_feature = "lse128")))]
+                        #[cfg(not(any(target_feature = "rcpc3", atomic_maybe_uninit_target_feature = "rcpc3")))]
+                        Ordering::Release => atomic_store!("", "dmb ish"),
+                        #[cfg(any(target_feature = "lse128", atomic_maybe_uninit_target_feature = "lse128"))]
+                        Ordering::SeqCst => atomic_rmw!(atomic_store_swpp, order),
+                        #[cfg(not(any(target_feature = "lse128", atomic_maybe_uninit_target_feature = "lse128")))]
+                        Ordering::SeqCst => atomic_store!("dmb ish", "dmb ish"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                #[cfg(not(any(target_feature = "lse2", atomic_maybe_uninit_target_feature = "lse2")))]
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! store {
+                        ($acquire:tt, $release:tt, $fence:tt) => {
+                            asm!(
+                                // load from val to val pair
+                                "ldp {val_lo}, {val_hi}, [{val}]",
+                                // (atomic) store val pair to dst (LL/SC loop)
+                                "2:",
+                                    // load from dst to xzr/tmp pair
+                                    concat!("ld", $acquire, "xp xzr, {tmp}, [{dst}]"),
+                                    // try to store val pair to dst
+                                    concat!("st", $release, "xp {tmp:w}, {val_lo}, {val_hi}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cbnz {tmp:w}, 2b",
+                                $fence,
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                val = in(reg) ptr_reg!(val),
+                                val_hi = out(reg) _,
+                                val_lo = out(reg) _,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(store, order);
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    #[cfg(any(target_feature = "lse128", atomic_maybe_uninit_target_feature = "lse128"))]
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt, $fence:tt) => {
+                            asm!(
+                                // load from val to val pair
+                                "ldp {val_lo}, {val_hi}, [{val}]",
+                                // (atomic) swap
+                                concat!("swpp", $acquire, $release, " {val_lo}, {val_hi}, [{dst}]"),
+                                $fence,
+                                // store out pair to out
+                                "stp {val_lo}, {val_hi}, [{out}]",
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(reg) ptr_reg!(val),
+                                out = in(reg) ptr_reg!(out_ptr),
+                                val_hi = out(reg) _,
+                                val_lo = out(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    #[cfg(not(any(target_feature = "lse128", atomic_maybe_uninit_target_feature = "lse128")))]
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt, $fence:tt) => {
+                            asm!(
+                                // load from val to val pair
+                                "ldp {val_lo}, {val_hi}, [{val}]",
+                                // (atomic) swap (LL/SC loop)
+                                "2:",
+                                    // load from dst to out pair
+                                    concat!("ld", $acquire, "xp {out_lo}, {out_hi}, [{dst}]"),
+                                    // try to store val pair to dst
+                                    concat!("st", $release, "xp {r:w}, {val_lo}, {val_hi}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cbnz {r:w}, 2b",
+                                $fence,
+                                // store out pair to out
+                                "stp {out_lo}, {out_hi}, [{out}]",
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                val = in(reg) ptr_reg!(val),
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                val_hi = out(reg) _,
+                                val_lo = out(reg) _,
+                                out_hi = out(reg) _,
+                                out_lo = out(reg) _,
+                                r = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32;
+                    #[cfg(any(target_feature = "lse", atomic_maybe_uninit_target_feature = "lse"))]
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt, $fence:tt) => {{
+                            asm!(
+                                // load from old/new to old/new pairs
+                                "ldp {old_lo}, {old_hi}, [{old}]",
+                                "ldp x4, x5, [{new}]",
+                                // casp writes the current value to the first register pair,
+                                // so copy the `old`'s value for later comparison.
+                                "mov x8, {old_lo}",
+                                "mov x9, {old_hi}",
+                                // (atomic) CAS
+                                // Refs: https://developer.arm.com/documentation/dui0801/g/A64-Data-Transfer-Instructions/CASPA--CASPAL--CASP--CASPL--CASPAL--CASP--CASPL
+                                concat!("casp", $acquire, $release, " x8, x9, x4, x5, [{dst}]"),
+                                $fence,
+                                // compare old pair and out pair
+                                "cmp x8, {old_lo}",
+                                "ccmp x9, {old_hi}, #0, eq",
+                                "cset {r:w}, eq",
+                                // store out pair to out
+                                "stp x8, x9, [{out}]",
+                                dst = in(reg) ptr_reg!(dst),
+                                old = in(reg) ptr_reg!(old),
+                                new = in(reg) ptr_reg!(new),
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                old_lo = out(reg) _,
+                                old_hi = out(reg) _,
+                                r = lateout(reg) r,
+                                // new pair - must be allocated to even/odd register pair
+                                out("x4") _, // new_lo
+                                out("x5") _, // new_hi
+                                // out pair - must be allocated to even/odd register pair
+                                out("x8") _, // out_lo
+                                out("x9") _, // out_hi
+                                // Do not use `preserves_flags` because CMP and CCMP modify the condition flags.
+                                options(nostack),
+                            );
+                            debug_assert!(r == 0 || r == 1, "r={}", r);
+                            (out, r != 0)
+                        }};
+                    }
+                    #[cfg(not(any(target_feature = "lse", atomic_maybe_uninit_target_feature = "lse")))]
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt, $fence:tt) => {{
+                            asm!(
+                                // load from old/new to old/new pair
+                                "ldp {new_lo}, {new_hi}, [{new}]",
+                                "ldp {old_lo}, {old_hi}, [{old}]",
+                                // (atomic) CAS (LL/SC loop)
+                                "2:",
+                                    concat!("ld", $acquire, "xp {out_lo}, {out_hi}, [{dst}]"),
+                                    "cmp {out_lo}, {old_lo}",
+                                    "cset {r:w}, ne",
+                                    "cmp {out_hi}, {old_hi}",
+                                    "cinc {r:w}, {r:w}, ne",
+                                    "cbz {r:w}, 3f", // jump if compare succeed
+                                    concat!("st", $release, "xp {r:w}, {out_lo}, {out_hi}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cbnz {r:w}, 2b", // continue loop if store failed
+                                    "mov {r:w}, #1", // mark as failed
+                                    "b 4f",
+                                "3:",
+                                    concat!("st", $release, "xp {r:w}, {new_lo}, {new_hi}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cbnz {r:w}, 2b", // continue loop if store failed
+                                "4:",
+                                $fence,
+                                // store out_tmp to out
+                                "stp {out_lo}, {out_hi}, [{out}]",
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                old = in(reg) ptr_reg!(old),
+                                old_hi = out(reg) _,
+                                old_lo = out(reg) _,
+                                new = in(reg) ptr_reg!(new),
+                                new_hi = out(reg) _,
+                                new_lo = out(reg) _,
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                out_hi = out(reg) _,
+                                out_lo = out(reg) _,
+                                r = lateout(reg) r,
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                            );
+                            debug_assert!(r == 0 || r == 1, "r={}", r);
+                            // 0 if the store was successful, 1 if no store was performed
+                            (out, r == 0)
+                        }};
+                    }
+                    atomic_rmw!(cmpxchg, order, write = success)
+                }
+            }
+        }
+    };
+}
+
+atomic128!(i128);
+atomic128!(u128);
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}

--- a/src/arch_legacy/arm.rs
+++ b/src/arch_legacy/arm.rs
@@ -1,0 +1,1165 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// ARMv6 and ARMv7
+//
+// Refs:
+// - ARM Architecture Reference Manual ARMv7-A and ARMv7-R edition
+//   https://developer.arm.com/documentation/ddi0406/cb
+// - ARMv6 Differences
+//   https://developer.arm.com/documentation/ddi0406/cb/Appendixes/ARMv6-Differences?lang=en
+//
+// Generated asm:
+// - armv7-a https://godbolt.org/z/P93x9TjWs
+// - armv7-r https://godbolt.org/z/1z9q9vTcd
+// - armv7-m https://godbolt.org/z/WozEfbMbx
+// - armv6 https://godbolt.org/z/T5M337jYK
+// - armv6-m https://godbolt.org/z/q88qPah4W
+
+use core::{
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+#[cfg(any(
+    any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"),
+    not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")),
+))]
+use crate::raw::{AtomicCompareExchange, AtomicSwap};
+use crate::raw::{AtomicLoad, AtomicStore};
+
+#[cfg(any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"))]
+#[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+macro_rules! dmb {
+    () => {
+        "dmb ish"
+    };
+}
+// ARMv6 does not support `dmb ish`, so use use special instruction equivalent to a DMB.
+//
+// Refs:
+// - https://reviews.llvm.org/D5386
+// - https://developer.arm.com/documentation/ddi0360/e/control-coprocessor-cp15/register-descriptions/c7--cache-operations-register?lang=en
+#[cfg(not(any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7")))]
+#[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+macro_rules! dmb {
+    () => {
+        "mcr p15, #0, r0, c7, c10, #5"
+    };
+}
+// Only a full system barrier exists in the M-class architectures.
+#[cfg(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass"))]
+macro_rules! dmb {
+    () => {
+        "dmb sy"
+    };
+}
+
+#[cfg(any(
+    any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"),
+    not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")),
+))]
+#[cfg(any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"))]
+macro_rules! clrex {
+    () => {
+        "clrex"
+    };
+}
+#[cfg(any(
+    any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"),
+    not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")),
+))]
+#[cfg(not(any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7")))]
+macro_rules! clrex {
+    () => {
+        ""
+    };
+}
+
+// On ARMv6, dmb! refers to r0, so when calling it, we must clobbering r0.
+macro_rules! asm_no_dmb {
+    (options($($options:tt)*), $($asm:tt)*) => {
+        core::arch::asm!(
+            $($asm)*
+            options($($options)*),
+        )
+    };
+}
+#[cfg(any(
+    target_feature = "v7",
+    atomic_maybe_uninit_target_feature = "v7",
+    target_feature = "mclass",
+    atomic_maybe_uninit_target_feature = "mclass",
+))]
+macro_rules! asm_use_dmb {
+    (options($($options:tt)*), $($asm:tt)*) => {
+        core::arch::asm!(
+            $($asm)*
+            options($($options)*),
+        )
+    };
+}
+#[cfg(not(any(
+    target_feature = "v7",
+    atomic_maybe_uninit_target_feature = "v7",
+    target_feature = "mclass",
+    atomic_maybe_uninit_target_feature = "mclass",
+)))]
+macro_rules! asm_use_dmb {
+    (options($($options:tt)*), $($asm:tt)*) => {
+        core::arch::asm!(
+            $($asm)*
+            inout("r0") 0_u32 => _,
+            options($($options)*),
+        )
+    };
+}
+
+macro_rules! atomic {
+    ($int_type:ident, $asm_suffix:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load {
+                        ($asm:ident, $acquire:expr) => {
+                            $asm!(
+                                options(nostack, preserves_flags),
+                                // (atomic) load from src to tmp
+                                concat!("ldr", $asm_suffix, " {tmp}, [{src}]"),
+                                $acquire, // acquire fence
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                src = in(reg) src,
+                                out = inout(reg) out_ptr => _,
+                                tmp = lateout(reg) _,
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!(asm_no_dmb, ""),
+                        // Acquire and SeqCst loads are equivalent.
+                        Ordering::Acquire | Ordering::SeqCst => atomic_load!(asm_use_dmb, dmb!()),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($asm:ident, $acquire:expr, $release:expr) => {
+                            $asm!(
+                                options(nostack, preserves_flags),
+                                // load from val to tmp
+                                concat!("ldr", $asm_suffix, " {tmp}, [{val}]"),
+                                // (atomic) store tmp to dst
+                                $release, // release fence
+                                concat!("str", $asm_suffix, " {tmp}, [{dst}]"),
+                                $acquire, // acquire fence
+                                dst = inout(reg) dst => _,
+                                val = in(reg) val,
+                                tmp = lateout(reg) _,
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_store!(asm_no_dmb, "", ""),
+                        Ordering::Release => atomic_store!(asm_use_dmb, "", dmb!()),
+                        Ordering::SeqCst => atomic_store!(asm_use_dmb, dmb!(), dmb!()),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+        #[cfg(any(
+            any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"),
+            not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")),
+        ))]
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_swap {
+                        ($asm:ident, $acquire:expr, $release:expr) => {
+                            $asm!(
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                                // load from val (ptr) to val (val)
+                                concat!("ldr", $asm_suffix, " {val}, [{val}]"),
+                                // (atomic) swap (LL/SC loop)
+                                $release, // release fence
+                                "2:",
+                                    // load from dst to tmp
+                                    concat!("ldrex", $asm_suffix, " {tmp}, [{dst}]"),
+                                    // try to store val to dst
+                                    concat!("strex", $asm_suffix, " {r}, {val}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, 0x0",
+                                    "bne 2b",
+                                $acquire, // acquire fence
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                dst = in(reg) dst,
+                                val = inout(reg) val => _,
+                                out = in(reg) out_ptr,
+                                r = out(reg) _,
+                                tmp = out(reg) _,
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_swap!(asm_no_dmb, "", ""),
+                        Ordering::Acquire => atomic_swap!(asm_use_dmb, dmb!(), ""),
+                        Ordering::Release => atomic_swap!(asm_use_dmb, "", dmb!()),
+                        // AcqRel and SeqCst swaps are equivalent.
+                        Ordering::AcqRel | Ordering::SeqCst => {
+                            atomic_swap!(asm_use_dmb, dmb!(), dmb!());
+                        }
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        #[rustfmt::skip]
+        #[cfg(any(
+            any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"),
+            not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")),
+        ))]
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
+                    let mut r: i32;
+                    macro_rules! cmpxchg_store_relaxed {
+                        ($asm:ident, $acquire_success:expr, $acquire_failure:expr) => {
+                            $asm!(
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                                // load from old/new (ptr) to old/new (val)
+                                concat!("ldr", $asm_suffix, " {old}, [{old}]"),
+                                concat!("ldr", $asm_suffix, " {new}, [{new}]"),
+                                // (atomic) CAS (LL/SC loop)
+                                "2:",
+                                    concat!("ldrex", $asm_suffix, " {tmp}, [{dst}]"),
+                                    "cmp {tmp}, {old}",
+                                    "bne 3f", // jump if compare failed
+                                    concat!("strex", $asm_suffix, " {r}, {new}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, #0",
+                                    "bne 2b", // continue loop if store failed
+                                    $acquire_success,
+                                    "b 4f",
+                                "3:",
+                                    // compare failed, set r to 1
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                    $acquire_failure,
+                                "4:",
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                dst = in(reg) dst,
+                                r = out(reg) r,
+                                old = inout(reg) old => _,
+                                new = inout(reg) new => _,
+                                out = in(reg) out_ptr,
+                                tmp = out(reg) _,
+                            )
+                        };
+                    }
+                    macro_rules! cmpxchg_release {
+                        ($acquire_failure:expr) => {
+                            asm_use_dmb!(
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                                // load from old/new (ptr) to old/new (val)
+                                concat!("ldr", $asm_suffix, " {old}, [{old}]"),
+                                concat!("ldr", $asm_suffix, " {new}, [{new}]"),
+                                // (atomic) CAS (LL/SC loop)
+                                concat!("ldrex", $asm_suffix, " {tmp}, [{dst}]"),
+                                "cmp {tmp}, {old}",
+                                "bne 3f", // jump if compare failed
+                                dmb!(), // release
+                                "2:",
+                                    concat!("strex", $asm_suffix, " {r}, {new}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, #0",
+                                    "beq 4f", // jump if store succeed
+                                    concat!("ldrex", $asm_suffix, " {tmp}, [{dst}]"),
+                                    "cmp {tmp}, {old}",
+                                    "beq 2b", // continue loop if compare succeed
+                                "3:",
+                                    // compare failed, set r to 1
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                    $acquire_failure,
+                                "4:",
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                dst = in(reg) dst,
+                                r = out(reg) r,
+                                old = inout(reg) old => _,
+                                new = inout(reg) new => _,
+                                out = in(reg) out_ptr,
+                                tmp = out(reg) _,
+                            )
+                        };
+                    }
+                    macro_rules! cmpxchg_acqrel {
+                        ($acquire_failure:expr) => {
+                            asm_use_dmb!(
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                                // load from old/new (ptr) to old/new (val)
+                                concat!("ldr", $asm_suffix, " {old}, [{old}]"),
+                                concat!("ldr", $asm_suffix, " {new}, [{new}]"),
+                                // (atomic) CAS (LL/SC loop)
+                                concat!("ldrex", $asm_suffix, " {tmp}, [{dst}]"),
+                                "cmp {tmp}, {old}",
+                                "bne 3f", // jump if compare failed
+                                dmb!(), // release
+                                "2:",
+                                    concat!("strex", $asm_suffix, " {r}, {new}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, #0",
+                                    "beq 4f", // jump if store succeed
+                                    concat!("ldrex", $asm_suffix, " {tmp}, [{dst}]"),
+                                    "cmp {tmp}, {old}",
+                                    "beq 2b", // continue loop if compare succeed
+                                "3:",
+                                    // compare failed, set r to 1
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                    $acquire_failure,
+                                    "b 5f",
+                                "4:", // store succeed
+                                    dmb!(), // acquire_success
+                                "5:",
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                dst = in(reg) dst,
+                                r = out(reg) r,
+                                old = inout(reg) old => _,
+                                new = inout(reg) new => _,
+                                out = in(reg) out_ptr,
+                                tmp = out(reg) _,
+                            )
+                        };
+                    }
+                    match (success, failure) {
+                        (Relaxed, Relaxed) => cmpxchg_store_relaxed!(asm_no_dmb, "", ""),
+                        (Relaxed, Acquire | SeqCst) => {
+                            cmpxchg_store_relaxed!(asm_use_dmb, "", dmb!());
+                        }
+                        (Acquire, Relaxed) => cmpxchg_store_relaxed!(asm_use_dmb, dmb!(), ""),
+                        (Acquire, Acquire | SeqCst) => {
+                            cmpxchg_store_relaxed!(asm_use_dmb, dmb!(), dmb!());
+                        }
+                        (Release, Relaxed) => cmpxchg_release!(""),
+                        (Release, Acquire | SeqCst) => cmpxchg_release!(dmb!()),
+                        // AcqRel and SeqCst compare_exchange are equivalent.
+                        (AcqRel | SeqCst, Relaxed) => cmpxchg_acqrel!(""),
+                        (AcqRel | SeqCst, _) => cmpxchg_acqrel!(dmb!()),
+                        _ => unreachable!("{:?}, {:?}", success, failure),
+                    }
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+            #[inline]
+            unsafe fn atomic_compare_exchange_weak(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
+                    let mut r: i32;
+                    macro_rules! cmpxchg_weak {
+                        ($asm:ident, $acquire:expr, $release:expr) => {
+                            $asm!(
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                                // load from old/new (ptr) to old/new (val)
+                                concat!("ldr", $asm_suffix, " {old}, [{old}]"),
+                                concat!("ldr", $asm_suffix, " {new}, [{new}]"),
+                                concat!("ldrex", $asm_suffix, " {tmp}, [{dst}]"),
+                                "cmp {tmp}, {old}",
+                                "bne 3f", // jump if compare failed
+                                $release,
+                                concat!("strex", $asm_suffix, " {r}, {new}, [{dst}]"),
+                                "b 4f",
+                                "3:",
+                                    // compare failed, set r to 1
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                "4:",
+                                $acquire,
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                dst = in(reg) dst,
+                                r = out(reg) r,
+                                old = inout(reg) old => _,
+                                new = inout(reg) new => _,
+                                out = in(reg) out_ptr,
+                                tmp = out(reg) _,
+                            )
+                        };
+                    }
+                    macro_rules! cmpxchg_weak_fail_load_relaxed {
+                        ($release:expr) => {
+                            asm_use_dmb!(
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                                // load from old/new (ptr) to old/new (val)
+                                concat!("ldr", $asm_suffix, " {old}, [{old}]"),
+                                concat!("ldr", $asm_suffix, " {new}, [{new}]"),
+                                concat!("ldrex", $asm_suffix, " {tmp}, [{dst}]"),
+                                "cmp {tmp}, {old}",
+                                "bne 3f", // jump if compare failed
+                                $release,
+                                concat!("strex", $asm_suffix, " {r}, {new}, [{dst}]"),
+                                // 0 if the store was successful, 1 if no store was performed
+                                "cmp {r}, #0",
+                                "beq 4f", // jump if store succeed
+                                "b 5f", // jump (store failed)
+                                "3:",
+                                    // compare failed, set r to 1
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                    "b 5f",
+                                "4:", // store succeed
+                                    dmb!(), // acquire_success
+                                "5:",
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                dst = in(reg) dst,
+                                r = out(reg) r,
+                                old = inout(reg) old => _,
+                                new = inout(reg) new => _,
+                                out = in(reg) out_ptr,
+                                tmp = out(reg) _,
+                            )
+                        };
+                    }
+                    macro_rules! cmpxchg_weak_success_load_relaxed {
+                        ($release:expr) => {
+                            asm_use_dmb!(
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                                // load from old/new (ptr) to old/new (val)
+                                concat!("ldr", $asm_suffix, " {old}, [{old}]"),
+                                concat!("ldr", $asm_suffix, " {new}, [{new}]"),
+                                concat!("ldrex", $asm_suffix, " {tmp}, [{dst}]"),
+                                "cmp {tmp}, {old}",
+                                "bne 3f", // jump if compare failed
+                                $release,
+                                concat!("strex", $asm_suffix, " {r}, {new}, [{dst}]"),
+                                // 0 if the store was successful, 1 if no store was performed
+                                "cmp {r}, #0",
+                                "beq 5f", // jump if store succeed
+                                "b 4f", // jump (store failed)
+                                "3:",
+                                    // compare failed, set r to 1
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                "4:", // compare or store failed
+                                    dmb!(), // acquire_failure
+                                "5:",
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                dst = in(reg) dst,
+                                r = out(reg) r,
+                                old = inout(reg) old => _,
+                                new = inout(reg) new => _,
+                                out = in(reg) out_ptr,
+                                tmp = out(reg) _,
+                            )
+                        };
+                    }
+                    match (success, failure) {
+                        (Relaxed, Relaxed) => cmpxchg_weak!(asm_no_dmb, "", ""),
+                        (Relaxed, Acquire | SeqCst) => cmpxchg_weak_success_load_relaxed!(""),
+                        (Acquire, Relaxed) => cmpxchg_weak_fail_load_relaxed!(""),
+                        (Acquire, Acquire | SeqCst) => cmpxchg_weak!(asm_use_dmb, dmb!(), ""),
+                        (Release, Relaxed) => cmpxchg_weak!(asm_use_dmb, "", dmb!()),
+                        (Release, Acquire | SeqCst) => cmpxchg_weak_success_load_relaxed!(dmb!()),
+                        // AcqRel and SeqCst compare_exchange_weak are equivalent.
+                        (AcqRel | SeqCst, Relaxed) => cmpxchg_weak_fail_load_relaxed!(dmb!()),
+                        (AcqRel | SeqCst, _) => cmpxchg_weak!(asm_use_dmb, dmb!(), dmb!()),
+                        _ => unreachable!("{:?}, {:?}", success, failure),
+                    }
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+        }
+    };
+}
+
+atomic!(i8, "b");
+atomic!(u8, "b");
+atomic!(i16, "h");
+atomic!(u16, "h");
+atomic!(i32, "");
+atomic!(u32, "");
+atomic!(isize, "");
+atomic!(usize, "");
+
+// Refs:
+// - https://developer.arm.com/documentation/ddi0406/cb/Application-Level-Architecture/Instruction-Details/Alphabetical-list-of-instructions/LDREXD
+// - https://developer.arm.com/documentation/ddi0406/cb/Application-Level-Architecture/Instruction-Details/Alphabetical-list-of-instructions/STREXD
+#[rustfmt::skip]
+macro_rules! atomic64 {
+    ($int_type:ident) => {
+        #[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load {
+                        ($asm:ident, $acquire:expr) => {
+                            $asm!(
+                                options(nostack, preserves_flags),
+                                // (atomic) load from src to tmp pair
+                                "ldrexd r2, r3, [{src}]",
+                                clrex!(),
+                                $acquire, // acquire fence
+                                // store tmp pair to out
+                                "strd r2, r3, [{out}]",
+                                src = in(reg) src,
+                                out = in(reg) out_ptr,
+                                // tmp pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!(asm_no_dmb, ""),
+                        // Acquire and SeqCst loads are equivalent.
+                        Ordering::Acquire | Ordering::SeqCst => atomic_load!(asm_use_dmb, dmb!()),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        #[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($asm:ident, $acquire:expr, $release:expr) => {
+                            $asm!(
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                                // load from val to val pair
+                                "ldrd r2, r3, [{val}]",
+                                // (atomic) store val pair to dst (LL/SC loop)
+                                $release, // release fence
+                                "2:",
+                                    // load from dst to tmp pair
+                                    "ldrexd r4, r5, [{dst}]",
+                                    // try to store val pair to dst
+                                    "strexd {r}, r2, r3, [{dst}]",
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, 0x0",
+                                    "bne 2b",
+                                $acquire, // acquire fence
+                                dst = inout(reg) dst => _,
+                                val = in(reg) val,
+                                r = lateout(reg) _,
+                                // val pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // tmp pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_store!(asm_no_dmb, "", ""),
+                        Ordering::Release => atomic_store!(asm_use_dmb, "", dmb!()),
+                        Ordering::SeqCst => atomic_store!(asm_use_dmb, dmb!(), dmb!()),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+        #[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_swap {
+                        ($asm:ident, $acquire:expr, $release:expr) => {
+                            $asm!(
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                                // load from val to val pair
+                                "ldrd r2, r3, [{val}]",
+                                // (atomic) swap (LL/SC loop)
+                                $release, // release fence
+                                "2:",
+                                    // load from dst to out pair
+                                    "ldrexd r4, r5, [{dst}]",
+                                    // try to store val pair to dst
+                                    "strexd {r}, r2, r3, [{dst}]",
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, 0x0",
+                                    "bne 2b",
+                                $acquire, // acquire fence
+                                // store out pair to out
+                                "strd r4, r5, [{out}]",
+                                dst = inout(reg) dst => _,
+                                val = in(reg) val,
+                                out = inout(reg) out_ptr => _,
+                                r = lateout(reg) _,
+                                // val pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // out pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_swap!(asm_no_dmb, "", ""),
+                        Ordering::Acquire => atomic_swap!(asm_use_dmb, dmb!(), ""),
+                        Ordering::Release => atomic_swap!(asm_use_dmb, "", dmb!()),
+                        // AcqRel and SeqCst swaps are equivalent.
+                        Ordering::AcqRel | Ordering::SeqCst => atomic_swap!(asm_use_dmb, dmb!(), dmb!()),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        #[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
+                    let mut r: i32;
+                    macro_rules! cmpxchg_store_relaxed {
+                        ($asm:ident, $acquire_success:expr, $acquire_failure:expr) => {
+                            $asm!(
+                                // Do not use `preserves_flags` because CMP and ORRS modify the condition flags.
+                                options(nostack),
+                                "ldrd r2, r3, [{old}]",
+                                "ldrd r8, r9, [{new}]",
+                                // (atomic) CAS (LL/SC loop)
+                                "2:",
+                                    "ldrexd r4, r5, [{dst}]",
+                                    "eor {tmp}, r5, r3",
+                                    "eor {r}, r4, r2",
+                                    "orrs {r}, {r}, {tmp}",
+                                    "bne 3f", // jump if compare failed
+                                    "strexd {r}, r8, r9, [{dst}]",
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, #0",
+                                    "bne 2b", // continue loop if store failed
+                                    $acquire_success,
+                                    "b 4f",
+                                "3:",
+                                    // compare failed, set r to 1 and clear exclusive
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                    $acquire_failure,
+                                "4:",
+                                // store out pair to out
+                                "strd r4, r5, [{out}]",
+                                dst = inout(reg) dst => _,
+                                r = lateout(reg) r,
+                                old = in(reg) old,
+                                new = in(reg) new,
+                                out = inout(reg) out_ptr => _,
+                                tmp = out(reg) _,
+                                // old pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // out pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                                // new pair - must be even-numbered and not R14
+                                out("r8") _,
+                                out("r9") _,
+                            )
+                        };
+                    }
+                    macro_rules! cmpxchg_release {
+                        ($acquire_failure:expr) => {
+                            asm_use_dmb!(
+                                // Do not use `preserves_flags` because CMP and ORRS modify the condition flags.
+                                options(nostack),
+                                "ldrd r2, r3, [{old}]",
+                                "ldrd r8, r9, [{new}]",
+                                // (atomic) CAS (LL/SC loop)
+                                "ldrexd r4, r5, [{dst}]",
+                                "eor {tmp}, r5, r3",
+                                "eor {r}, r4, r2",
+                                "orrs {r}, {r}, {tmp}",
+                                "bne 3f", // jump if compare failed
+                                dmb!(), // release
+                                "2:",
+                                    "strexd {r}, r8, r9, [{dst}]",
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, #0",
+                                    "beq 4f", // jump if store succeed
+                                    "ldrexd r4, r5, [{dst}]",
+                                    "eor {tmp}, r5, r3",
+                                    "eor {r}, r4, r2",
+                                    "orrs {r}, {r}, {tmp}",
+                                    "beq 2b", // continue loop if compare succeed
+                                "3:",
+                                    // compare failed, set r to 1 and clear exclusive
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                    $acquire_failure,
+                                "4:",
+                                // store out pair to out
+                                "strd r4, r5, [{out}]",
+                                dst = inout(reg) dst => _,
+                                r = lateout(reg) r,
+                                old = in(reg) old,
+                                new = in(reg) new,
+                                out = inout(reg) out_ptr => _,
+                                tmp = out(reg) _,
+                                // old pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // out pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                                // new pair - must be even-numbered and not R14
+                                out("r8") _,
+                                out("r9") _,
+                            )
+                        };
+                    }
+                    macro_rules! cmpxchg_acqrel {
+                        ($acquire_failure:expr) => {
+                            asm_use_dmb!(
+                                // Do not use `preserves_flags` because CMP and ORRS modify the condition flags.
+                                options(nostack),
+                                "ldrd r2, r3, [{old}]",
+                                "ldrd r8, r9, [{new}]",
+                                // (atomic) CAS (LL/SC loop)
+                                "ldrexd r4, r5, [{dst}]",
+                                "eor {tmp}, r5, r3",
+                                "eor {r}, r4, r2",
+                                "orrs {r}, {r}, {tmp}",
+                                "bne 3f", // jump if compare failed
+                                dmb!(), // release
+                                "2:",
+                                    "strexd {r}, r8, r9, [{dst}]",
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, #0",
+                                    "beq 4f", // jump if store succeed
+                                    "ldrexd r4, r5, [{dst}]",
+                                    "eor {tmp}, r5, r3",
+                                    "eor {r}, r4, r2",
+                                    "orrs {r}, {r}, {tmp}",
+                                    "beq 2b", // continue loop if compare succeed
+                                "3:",
+                                    // compare failed, set r to 1 and clear exclusive
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                    $acquire_failure,
+                                    "b 5f",
+                                "4:", // store succeed
+                                    dmb!(), // acquire_success
+                                "5:",
+                                // store out pair to out
+                                "strd r4, r5, [{out}]",
+                                dst = inout(reg) dst => _,
+                                r = lateout(reg) r,
+                                old = in(reg) old,
+                                new = in(reg) new,
+                                out = inout(reg) out_ptr => _,
+                                tmp = out(reg) _,
+                                // old pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // out pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                                // new pair - must be even-numbered and not R14
+                                out("r8") _,
+                                out("r9") _,
+                            )
+                        };
+                    }
+                    match (success, failure) {
+                        (Relaxed, Relaxed) => cmpxchg_store_relaxed!(asm_no_dmb, "", ""),
+                        (Relaxed, Acquire | SeqCst) => cmpxchg_store_relaxed!(asm_use_dmb, "", dmb!()),
+                        (Acquire, Relaxed) => cmpxchg_store_relaxed!(asm_use_dmb, dmb!(), ""),
+                        (Acquire, Acquire | SeqCst) => cmpxchg_store_relaxed!(asm_use_dmb, dmb!(), dmb!()),
+                        (Release, Relaxed) => cmpxchg_release!(""),
+                        (Release, Acquire | SeqCst) => cmpxchg_release!(dmb!()),
+                        // AcqRel and SeqCst compare_exchange are equivalent.
+                        (AcqRel | SeqCst, Relaxed) => cmpxchg_acqrel!(""),
+                        (AcqRel | SeqCst, _) => cmpxchg_acqrel!(dmb!()),
+                        _ => unreachable!("{:?}, {:?}", success, failure),
+                    }
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+            #[inline]
+            unsafe fn atomic_compare_exchange_weak(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
+                    let mut r: i32;
+                    macro_rules! cmpxchg_weak {
+                        ($asm:ident, $acquire:expr, $release:expr) => {
+                            $asm!(
+                                // Do not use `preserves_flags` because ORRS modifies the condition flags.
+                                options(nostack),
+                                "ldrd r2, r3, [{old}]",
+                                "ldrd r8, r9, [{new}]",
+                                "ldrexd r4, r5, [{dst}]",
+                                "eor {tmp}, r5, r3",
+                                "eor {r}, r4, r2",
+                                "orrs {r}, {r}, {tmp}",
+                                "bne 3f", // jump if compare failed
+                                $release,
+                                "strexd {r}, r8, r9, [{dst}]",
+                                "b 4f",
+                                "3:",
+                                    // compare failed, set r to 1 and clear exclusive
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                "4:",
+                                $acquire,
+                                // store out pair to out
+                                "strd r4, r5, [{out}]",
+                                dst = inout(reg) dst => _,
+                                r = lateout(reg) r,
+                                old = in(reg) old,
+                                new = in(reg) new,
+                                out = inout(reg) out_ptr => _,
+                                tmp = out(reg) _,
+                                // old pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // out pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                                // new pair - must be even-numbered and not R14
+                                out("r8") _,
+                                out("r9") _,
+                            )
+                        };
+                    }
+                    macro_rules! cmpxchg_weak_fail_load_relaxed {
+                        ($release:expr) => {
+                            asm_use_dmb!(
+                                // Do not use `preserves_flags` because CMP and ORRS modify the condition flags.
+                                options(nostack),
+                                "ldrd r2, r3, [{old}]",
+                                "ldrd r8, r9, [{new}]",
+                                "ldrexd r4, r5, [{dst}]",
+                                "eor {tmp}, r5, r3",
+                                "eor {r}, r4, r2",
+                                "orrs {r}, {r}, {tmp}",
+                                "bne 3f", // jump if compare failed
+                                $release,
+                                "strexd {r}, r8, r9, [{dst}]",
+                                // 0 if the store was successful, 1 if no store was performed
+                                "cmp {r}, #0",
+                                "beq 4f", // jump if store succeed
+                                "b 5f", // jump (store failed)
+                                "3:",
+                                    // compare failed, set r to 1 and clear exclusive
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                    "b 5f",
+                                "4:", // store succeed
+                                    dmb!(), // acquire_success
+                                "5:",
+                                // store out pair to out
+                                "strd r4, r5, [{out}]",
+                                dst = inout(reg) dst => _,
+                                r = lateout(reg) r,
+                                old = in(reg) old,
+                                new = in(reg) new,
+                                out = inout(reg) out_ptr => _,
+                                tmp = out(reg) _,
+                                // old pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // out pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                                // new pair - must be even-numbered and not R14
+                                out("r8") _,
+                                out("r9") _,
+                            )
+                        };
+                    }
+                    macro_rules! cmpxchg_weak_success_load_relaxed {
+                        ($release:expr) => {
+                            asm_use_dmb!(
+                                // Do not use `preserves_flags` because CMP and ORRS modify the condition flags.
+                                options(nostack),
+                                "ldrd r2, r3, [{old}]",
+                                "ldrd r8, r9, [{new}]",
+                                "ldrexd r4, r5, [{dst}]",
+                                "eor {tmp}, r5, r3",
+                                "eor {r}, r4, r2",
+                                "orrs {r}, {r}, {tmp}",
+                                "bne 3f", // jump if compare failed
+                                $release,
+                                "strexd {r}, r8, r9, [{dst}]",
+                                // 0 if the store was successful, 1 if no store was performed
+                                "cmp {r}, #0",
+                                "beq 5f", // jump if store succeed
+                                "b 4f", // jump (store failed)
+                                "3:",
+                                    // compare failed, set r to 1 and clear exclusive
+                                    "mov {r}, #1",
+                                    clrex!(),
+                                    "4:", // compare or store failed
+                                    dmb!(), // acquire_failure
+                                "5:",
+                                // store out pair to out
+                                "strd r4, r5, [{out}]",
+                                dst = inout(reg) dst => _,
+                                r = lateout(reg) r,
+                                old = in(reg) old,
+                                new = in(reg) new,
+                                out = inout(reg) out_ptr => _,
+                                tmp = out(reg) _,
+                                // old pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // out pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                                // new pair - must be even-numbered and not R14
+                                out("r8") _,
+                                out("r9") _,
+                            )
+                        };
+                    }
+                    match (success, failure) {
+                        (Relaxed, Relaxed) => cmpxchg_weak!(asm_no_dmb, "", ""),
+                        (Relaxed, Acquire | SeqCst) => cmpxchg_weak_success_load_relaxed!(""),
+                        (Acquire, Relaxed) => cmpxchg_weak_fail_load_relaxed!(""),
+                        (Acquire, Acquire | SeqCst) => cmpxchg_weak!(asm_use_dmb, dmb!(), ""),
+                        (Release, Relaxed) => cmpxchg_weak!(asm_use_dmb, "", dmb!()),
+                        (Release, Acquire | SeqCst) => cmpxchg_weak_success_load_relaxed!(dmb!()),
+                        // AcqRel and SeqCst compare_exchange_weak are equivalent.
+                        (AcqRel | SeqCst, Relaxed) => cmpxchg_weak_fail_load_relaxed!(dmb!()),
+                        (AcqRel | SeqCst, _) => cmpxchg_weak!(asm_use_dmb, dmb!(), dmb!()),
+                        _ => unreachable!("{:?}, {:?}", success, failure),
+                    }
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+        }
+    };
+}
+
+atomic64!(i64);
+atomic64!(u64);
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass"))]
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass"))]
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(any(
+    any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"),
+    not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")),
+))]
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(any(
+    any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"),
+    not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")),
+))]
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}
+#[cfg(not(any(
+    any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"),
+    not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")),
+)))]
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => {};
+}
+#[cfg(not(any(
+    any(target_feature = "v7", atomic_maybe_uninit_target_feature = "v7"),
+    not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")),
+)))]
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}

--- a/src/arch_legacy/arm_linux.rs
+++ b/src/arch_legacy/arm_linux.rs
@@ -1,0 +1,670 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Pre-v6 ARM Linux/Android
+//
+// Refs:
+// - https://www.kernel.org/doc/Documentation/arm/kernel_user_helpers.txt
+// - https://github.com/rust-lang/compiler-builtins/blob/0.1.88/src/arm_linux.rs
+// - ARMv4 and ARMv5 Differences
+//   https://developer.arm.com/documentation/ddi0406/cb/Appendixes/ARMv4-and-ARMv5-Differences?lang=en
+//
+// Generated asm:
+// - armv5te https://godbolt.org/z/r61s7cnG8
+// - armv4t https://godbolt.org/z/xrxfKx1rc
+
+#[path = "../arch/partword.rs"]
+mod partword;
+
+use core::{
+    arch::asm,
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+use crate::raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap};
+
+type XSize = usize;
+
+// https://www.kernel.org/doc/Documentation/arm/kernel_user_helpers.txt
+const KUSER_HELPER_VERSION: usize = 0xFFFF0FFC;
+// __kuser_helper_version >= 2 (kernel version 2.6.12+)
+const KUSER_CMPXCHG: usize = 0xFFFF0FC0;
+// __kuser_helper_version >= 3 (kernel version 2.6.15+)
+const KUSER_MEMORY_BARRIER: usize = 0xFFFF0FA0;
+// __kuser_helper_version >= 5 (kernel version 3.1+)
+const KUSER_CMPXCHG64: usize = 0xFFFF0F60;
+
+#[inline]
+fn kuser_helper_version() -> i32 {
+    // SAFETY: core assumes that at least __kuser_memory_barrier (__kuser_helper_version >= 3) is
+    // available on this platform. __kuser_helper_version is always available on such a platform.
+    unsafe { (KUSER_HELPER_VERSION as *const i32).read() }
+}
+
+#[cfg(any(target_feature = "v5te", atomic_maybe_uninit_target_feature = "v5te"))]
+macro_rules! blx {
+    ($addr:tt) => {
+        concat!("blx ", $addr)
+    };
+}
+#[cfg(not(any(target_feature = "v5te", atomic_maybe_uninit_target_feature = "v5te")))]
+macro_rules! blx {
+    ($addr:tt) => {
+        concat!("mov lr, pc", "\n", "bx ", $addr)
+    };
+}
+
+macro_rules! atomic_load_store {
+    ($int_type:ident, $asm_suffix:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    match order {
+                        Ordering::Relaxed => {
+                            asm!(
+                                // (atomic) load from src to tmp
+                                concat!("ldr", $asm_suffix, " {tmp}, [{src}]"),
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                src = in(reg) src,
+                                out = inout(reg) out_ptr => _,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            );
+                        }
+                        // Acquire and SeqCst loads are equivalent.
+                        Ordering::Acquire | Ordering::SeqCst => {
+                            debug_assert!(kuser_helper_version() >= 3);
+                            asm!(
+                                // (atomic) load from src to tmp
+                                concat!("ldr", $asm_suffix, " {tmp}, [{src}]"),
+                                blx!("{kuser_memory_barrier}"), // acquire fence
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                src = in(reg) src,
+                                out = inout(reg) out_ptr => _,
+                                tmp = lateout(reg) _,
+                                kuser_memory_barrier = inout(reg) KUSER_MEMORY_BARRIER => _,
+                                out("lr") _,
+                                options(nostack, preserves_flags),
+                            );
+                        }
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store_release {
+                        ($acquire:expr) => {{
+                            debug_assert!(kuser_helper_version() >= 3);
+                            asm!(
+                                // load from val to tmp
+                                concat!("ldr", $asm_suffix, " {tmp}, [{val}]"),
+                                // (atomic) store tmp to dst
+                                blx!("{kuser_memory_barrier}"), // release fence
+                                concat!("str", $asm_suffix, " {tmp}, [{dst}]"),
+                                $acquire, // acquire fence
+                                dst = inout(reg) dst => _,
+                                val = in(reg) val,
+                                tmp = lateout(reg) _,
+                                kuser_memory_barrier = inout(reg) KUSER_MEMORY_BARRIER => _,
+                                out("lr") _,
+                                options(nostack, preserves_flags),
+                            )
+                        }};
+                    }
+                    match order {
+                        Ordering::Relaxed => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("ldr", $asm_suffix, " {tmp}, [{val}]"),
+                                // (atomic) store tmp to dst
+                                concat!("str", $asm_suffix, " {tmp}, [{dst}]"),
+                                dst = inout(reg) dst => _,
+                                val = in(reg) val,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            );
+                        }
+                        Ordering::Release => atomic_store_release!(""),
+                        Ordering::SeqCst => atomic_store_release!(blx!("{kuser_memory_barrier}")),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! atomic {
+    ($int_type:ident) => {
+        atomic_load_store!($int_type, "");
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                debug_assert!(kuser_helper_version() >= 2);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        "ldr r1, [r1]", // new_val
+                        "2:",
+                            "ldr r0, [r2]", // old_val
+                            "mov {out_tmp}, r0",
+                            blx!("{kuser_cmpxchg}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                        "str {out_tmp}, [{out}]",
+                        out = in(reg) out_ptr,
+                        out_tmp = out(reg) _,
+                        kuser_cmpxchg = in(reg) KUSER_CMPXCHG,
+                        out("r0") _,
+                        inout("r1") val => _,
+                        in("r2") dst, // ptr
+                        out("r3") _,
+                        out("ip") _,
+                        out("lr") _,
+                        // Do not use `preserves_flags` because CMP and __kuser_cmpxchg modify the condition flags.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                debug_assert!(kuser_helper_version() >= 2);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32;
+                    asm!(
+                        "ldr {old}, [{old}]",
+                        "ldr {new}, [{new}]",
+                        "2:",
+                            "ldr r0, [r2]", // old_val
+                            "mov {out_tmp}, r0",
+                            "cmp r0, {old}",
+                            "bne 3f",
+                            "mov r1, {new}", // new_val
+                            blx!("{kuser_cmpxchg}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                            "b 4f",
+                        "3:",
+                            // write back to synchronize
+                            "mov r1, r0", // new_val
+                            blx!("{kuser_cmpxchg}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                            "mov r0, #1",
+                        "4:",
+                        "str {out_tmp}, [{out}]",
+                        old = inout(reg) old => _,
+                        new = inout(reg) new => _,
+                        out = in(reg) out_ptr,
+                        out_tmp = out(reg) _,
+                        kuser_cmpxchg = in(reg) KUSER_CMPXCHG,
+                        out("r0") r,
+                        out("r1") _,
+                        in("r2") dst, // ptr
+                        out("r3") _,
+                        out("ip") _,
+                        out("lr") _,
+                        // Do not use `preserves_flags` because CMP and __kuser_cmpxchg modify the condition flags.
+                        options(nostack),
+                    );
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+        }
+    };
+}
+
+macro_rules! atomic_sub_word {
+    ($int_type:ident, $asm_suffix:tt) => {
+        atomic_load_store!($int_type, $asm_suffix);
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                debug_assert!(kuser_helper_version() >= 2);
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        concat!("ldr", $asm_suffix, " {val}, [{val}]"),
+                        "lsl {mask}, {mask}, {shift}",
+                        "lsl {val}, {val}, {shift}",
+                        "and {val}, {val}, {mask}",
+                        "mvn {inv_mask}, {mask}",
+                        "2:",
+                            "ldr r0, [r2]", // old_val
+                            "mov {out_tmp}, r0",
+                            "and r1, r0, {inv_mask}",
+                            "orr r1, r1, {val}", // new_val
+                            blx!("{kuser_cmpxchg}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                        "lsr {out_tmp}, {out_tmp}, {shift}",
+                        concat!("str", $asm_suffix, " {out_tmp}, [{out}]"),
+                        val = inout(reg) val => _,
+                        out = in(reg) out_ptr,
+                        shift = in(reg) shift,
+                        mask = inout(reg) mask => _,
+                        inv_mask = out(reg) _,
+                        out_tmp = out(reg) _,
+                        kuser_cmpxchg = in(reg) KUSER_CMPXCHG,
+                        out("r0") _,
+                        out("r1") _,
+                        in("r2") aligned_ptr, // ptr
+                        out("r3") _,
+                        out("ip") _,
+                        out("lr") _,
+                        // Do not use `preserves_flags` because CMP and __kuser_cmpxchg modify the condition flags.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                debug_assert!(kuser_helper_version() >= 2);
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32;
+                    asm!(
+                        concat!("ldr", $asm_suffix, " {old}, [{old}]"),
+                        concat!("ldr", $asm_suffix, " {new}, [{new}]"),
+                        "lsl {mask}, {mask}, {shift}",
+                        "lsl {old}, {old}, {shift}",
+                        "lsl {new}, {new}, {shift}",
+                        "and {old}, {old}, {mask}",
+                        "and {new}, {new}, {mask}",
+                        // We cannot create inv_mask here because there are no available registers
+                        // "mvn {inv_mask}, {mask}",
+                        "2:",
+                            "ldr r0, [r2]", // old_val
+                            "and {out_tmp}, r0, {mask}",
+                            "cmp {out_tmp}, {old}",
+                            "bne 3f",
+                            "mvn r1, {mask}",
+                            "and r1, r0, r1",
+                            "orr r1, r1, {new}", // new_val
+                            blx!("{kuser_cmpxchg}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                            "b 4f",
+                        "3:",
+                            // write back to synchronize
+                            "mov r1, r0", // new_val
+                            blx!("{kuser_cmpxchg}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                            "mov r0, #1",
+                        "4:",
+                        "lsr {out_tmp}, {out_tmp}, {shift}",
+                        concat!("str", $asm_suffix, " {out_tmp}, [{out}]"),
+                        old = inout(reg) old => _,
+                        new = inout(reg) new => _,
+                        out = in(reg) out_ptr,
+                        shift = in(reg) shift,
+                        mask = inout(reg) mask => _,
+                        out_tmp = out(reg) _,
+                        kuser_cmpxchg = in(reg) KUSER_CMPXCHG,
+                        out("r0") r,
+                        out("r1") _,
+                        in("r2") aligned_ptr, // ptr
+                        out("r3") _,
+                        out("ip") _,
+                        out("lr") _,
+                        // Do not use `preserves_flags` because CMP and __kuser_cmpxchg modify the condition flags.
+                        options(nostack),
+                    );
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+        }
+    };
+}
+
+atomic_sub_word!(i8, "b");
+atomic_sub_word!(u8, "b");
+atomic_sub_word!(i16, "h");
+atomic_sub_word!(u16, "h");
+atomic!(i32);
+atomic!(u32);
+atomic!(isize);
+atomic!(usize);
+
+macro_rules! atomic64 {
+    ($int_type:ident) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                assert_has_kuser_cmpxchg64();
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        "2:",
+                            "ldr r0, [r2]",
+                            "ldr r3, [r2, #4]",
+                            "str r0, [r1]",
+                            "str r3, [r1, #4]",
+                            "mov r0, r1", // old_val
+                            blx!("{kuser_cmpxchg64}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                        kuser_cmpxchg64 = in(reg) KUSER_CMPXCHG64,
+                        out("r0") _,
+                        in("r1") out_ptr, // new_val
+                        in("r2") src, // ptr
+                        out("r3") _,
+                        out("lr") _,
+                        // Do not use `preserves_flags` because CMP and __kuser_cmpxchg64 modify the condition flags.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                assert_has_kuser_cmpxchg64();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut out_tmp = MaybeUninit::<Self>::uninit();
+                    asm!(
+                        "2:",
+                            "ldr r0, [r2]",
+                            "ldr r3, [r2, #4]",
+                            "str r0, [{out_tmp}]",
+                            "str r3, [{out_tmp}, #4]",
+                            "mov r0, {out_tmp}", // old_val
+                            blx!("{kuser_cmpxchg64}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                        out_tmp = in(reg) out_tmp.as_mut_ptr(),
+                        kuser_cmpxchg64 = in(reg) KUSER_CMPXCHG64,
+                        out("r0") _,
+                        in("r1") val, // new_val
+                        in("r2") dst, // ptr
+                        out("r3") _,
+                        out("lr") _,
+                        // Do not use `preserves_flags` because CMP and __kuser_cmpxchg64 modify the condition flags.
+                        options(nostack),
+                    );
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                assert_has_kuser_cmpxchg64();
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        "2:",
+                            "ldr r0, [r2]",
+                            "ldr r3, [r2, #4]",
+                            "str r0, [{out_tmp}]",
+                            "str r3, [{out_tmp}, #4]",
+                            "mov r0, {out_tmp}", // old_val
+                            blx!("{kuser_cmpxchg64}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                        out_tmp = in(reg) out_ptr,
+                        kuser_cmpxchg64 = in(reg) KUSER_CMPXCHG64,
+                        out("r0") _,
+                        in("r1") val, // new_val
+                        in("r2") dst, // ptr
+                        out("r3") _,
+                        out("lr") _,
+                        // Do not use `preserves_flags` because CMP and __kuser_cmpxchg64 modify the condition flags.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                assert_has_kuser_cmpxchg64();
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32;
+                    asm!(
+                        "ldr {old_lo}, [{old_hi}]",
+                        "ldr {old_hi}, [{old_hi}, #4]",
+                        "2:",
+                            "ldr r0, [r2]",
+                            "ldr r3, [r2, #4]",
+                            "str r0, [{out_tmp}]",
+                            "str r3, [{out_tmp}, #4]",
+                            "eor r0, r0, {old_lo}",
+                            "eor r3, r3, {old_hi}",
+                            "orrs r0, r0, r3",
+                            "bne 3f",
+                            "mov r0, {out_tmp}", // old_val
+                            "mov r1, {new}", // new_val
+                            blx!("{kuser_cmpxchg64}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                            "b 4f",
+                        "3:",
+                            // write back to ensure atomicity
+                            "mov r0, {out_tmp}", // old_val
+                            "mov r1, {out_tmp}", // new_val
+                            blx!("{kuser_cmpxchg64}"),
+                            "cmp r0, #0",
+                            "bne 2b",
+                            "mov r0, #1",
+                        "4:",
+                        new = in(reg) new,
+                        out_tmp = in(reg) out_ptr,
+                        old_lo = out(reg) _,
+                        old_hi = inout(reg) old => _,
+                        kuser_cmpxchg64 = in(reg) KUSER_CMPXCHG64,
+                        out("r0") r,
+                        out("r1") _,
+                        in("r2") dst, // ptr
+                        out("r3") _,
+                        out("lr") _,
+                        // Do not use `preserves_flags` because CMP, ORRS, and __kuser_cmpxchg64 modify the condition flags.
+                        options(nostack),
+                    );
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+        }
+    };
+}
+
+atomic64!(i64);
+atomic64!(u64);
+
+// TODO: Since Rust 1.64, the Linux kernel requirement for Rust when using std is 3.2+, so it
+// should be possible to convert this to debug_assert if the std feature is enabled on Rust 1.64+.
+// https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html
+#[inline]
+fn assert_has_kuser_cmpxchg64() {
+    if kuser_helper_version() < 5 {
+        #[cold]
+        fn p() -> ! {
+            panic!("64-bit atomics on pre-v6 ARM requires Linux kernel version 3.1+")
+        }
+        p()
+    }
+}
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+// TODO: set has_atomic_64 to true
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn kuser_helper_version() {
+        let version = super::kuser_helper_version();
+        assert!(version >= 5, "{:?}", version);
+    }
+
+    // TODO: set has_atomic_64 to true
+    test_atomic!(i64);
+    test_atomic!(u64);
+    stress_test!(u64);
+}

--- a/src/arch_legacy/armv8.rs
+++ b/src/arch_legacy/armv8.rs
@@ -1,0 +1,641 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// ARMv8 AArch32
+//
+// LLVM doesn't generate CLREX for ARMv8-M Baseline, but it actually supports CLREX.
+// https://developer.arm.com/documentation/dui1095/a/The-Cortex-M23-Instruction-Set/Memory-access-instructions?lang=en
+// https://community.arm.com/cfs-file/__key/telligent-evolution-components-attachments/01-2057-00-00-00-01-28-35/Cortex_2D00_M-for-Beginners-_2D00_-2017_5F00_EN_5F00_v2.pdf
+//
+// Refs:
+// - Arm Architecture Reference Manual for A-profile architecture
+//   https://developer.arm.com/documentation/ddi0487/latest
+// - Armv8-M Architecture Reference Manual
+//   https://developer.arm.com/documentation/ddi0553/latest
+//
+// Generated asm:
+// - armv8-a https://godbolt.org/z/Mx8z81463
+// - armv8-m baseline https://godbolt.org/z/P51ezojjW
+// - armv8-m mainline https://godbolt.org/z/WdajnbYTr
+
+use core::{
+    arch::asm,
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+use crate::raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap};
+
+macro_rules! atomic_rmw {
+    ($op:ident, $order:ident) => {
+        match $order {
+            Ordering::Relaxed => $op!("r", "r"),
+            Ordering::Acquire => $op!("a", "r"),
+            Ordering::Release => $op!("r", "l"),
+            // AcqRel and SeqCst RMWs are equivalent.
+            Ordering::AcqRel | Ordering::SeqCst => $op!("a", "l"),
+            _ => unreachable!("{:?}", $order),
+        }
+    };
+}
+
+// Adds S suffix if needed. We prefer instruction without S suffix,
+// but ARMv8-M Baseline doesn't support thumb2 instructions.
+#[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+macro_rules! s {
+    ($op:tt, $operand:tt) => {
+        concat!($op, " ", $operand)
+    };
+}
+#[cfg(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass"))]
+macro_rules! s {
+    ($op:tt, $operand:tt) => {
+        concat!($op, "s ", $operand)
+    };
+}
+
+macro_rules! atomic {
+    ($int_type:ident, $asm_suffix:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load {
+                        ($acquire:tt) => {
+                            asm!(
+                                // (atomic) load from src to tmp
+                                concat!("ld", $acquire, $asm_suffix, " {tmp}, [{src}]"),
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                src = in(reg) src,
+                                out = inout(reg) out_ptr => _,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!("r"),
+                        // Acquire and SeqCst loads are equivalent.
+                        Ordering::Acquire | Ordering::SeqCst => atomic_load!("a"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($release:tt) => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("ldr", $asm_suffix, " {tmp}, [{val}]"),
+                                // (atomic) store tmp to dst
+                                concat!("st", $release, $asm_suffix, " {tmp}, [{dst}]"),
+                                dst = inout(reg) dst => _,
+                                val = in(reg) val,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_store!("r"),
+                        // Release and SeqCst stores are equivalent.
+                        Ordering::Release | Ordering::SeqCst => atomic_store!("l"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from val (ptr) to val (val)
+                                concat!("ldr", $asm_suffix, " {val}, [{val}]"),
+                                // (atomic) swap (LL/SC loop)
+                                "2:",
+                                    // load from dst to tmp
+                                    concat!("ld", $acquire, "ex", $asm_suffix, " {tmp}, [{dst}]"),
+                                    // try to store val to dst
+                                    concat!("st", $release, "ex", $asm_suffix, " {r}, {val}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, 0x0",
+                                    "bne 2b",
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                dst = in(reg) dst,
+                                val = inout(reg) val => _,
+                                out = in(reg) out_ptr,
+                                r = out(reg) _,
+                                tmp = out(reg) _,
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32;
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from old/new (ptr) to old/new (val)
+                                concat!("ldr", $asm_suffix, " {old}, [{old}]"),
+                                concat!("ldr", $asm_suffix, " {new}, [{new}]"),
+                                // (atomic) CAS (LL/SC loop)
+                                "2:",
+                                    // load from dst to tmp
+                                    concat!("ld", $acquire, "ex", $asm_suffix, " {tmp}, [{dst}]"),
+                                    "cmp {tmp}, {old}",
+                                    "bne 3f", // jump if compare failed
+                                    // try to store val to dst
+                                    concat!("st", $release, "ex", $asm_suffix, " {r}, {new}, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, #0",
+                                    "bne 2b", // continue loop if store failed
+                                    "b 4f",
+                                "3:",
+                                    // compare failed, mark r as failed and clear exclusive
+                                    "clrex",
+                                    s!("mov", "{r}, #1"),
+                                "4:",
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                dst = in(reg) dst,
+                                old = inout(reg) old => _,
+                                new = inout(reg) new => _,
+                                out = in(reg) out_ptr,
+                                r = out(reg) r,
+                                tmp = out(reg) _,
+                                // Do not use `preserves_flags` because CMP and s! modify the condition flags.
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg, order);
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+            #[inline]
+            unsafe fn atomic_compare_exchange_weak(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32;
+                    macro_rules! cmpxchg_weak {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from old/new (ptr) to old/new (val)
+                                concat!("ldr", $asm_suffix, " {old}, [{old}]"),
+                                concat!("ldr", $asm_suffix, " {new}, [{new}]"),
+                                // load from dst to tmp
+                                concat!("ld", $acquire, "ex", $asm_suffix, " {tmp}, [{dst}]"),
+                                "cmp {tmp}, {old}",
+                                "bne 3f",
+                                // try to store new to dst
+                                concat!("st", $release, "ex", $asm_suffix, " {r}, {new}, [{dst}]"),
+                                "b 4f",
+                                "3:",
+                                    // compare failed, mark r as failed and clear exclusive
+                                    "clrex",
+                                    s!("mov", "{r}, #1"),
+                                "4:",
+                                // store tmp to out
+                                concat!("str", $asm_suffix, " {tmp}, [{out}]"),
+                                dst = in(reg) dst,
+                                old = inout(reg) old => _,
+                                new = inout(reg) new => _,
+                                out = in(reg) out_ptr,
+                                r = out(reg) r,
+                                tmp = out(reg) _,
+                                // Do not use `preserves_flags` because CMP and s! modify the condition flags.
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg_weak, order);
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+        }
+    };
+}
+
+atomic!(i8, "b");
+atomic!(u8, "b");
+atomic!(i16, "h");
+atomic!(u16, "h");
+atomic!(i32, "");
+atomic!(u32, "");
+atomic!(isize, "");
+atomic!(usize, "");
+
+#[rustfmt::skip]
+macro_rules! atomic64 {
+    ($int_type:ident) => {
+        #[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load {
+                        ($acquire:tt) => {
+                            asm!(
+                                // (atomic) load from src to tmp pair
+                                concat!("ld", $acquire, "exd r2, r3, [{src}]"),
+                                "clrex",
+                                // store tmp pair to out
+                                "strd r2, r3, [{out}]",
+                                src = in(reg) src,
+                                out = in(reg) out_ptr,
+                                // tmp pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!("r"),
+                        // Acquire and SeqCst loads are equivalent.
+                        Ordering::Acquire | Ordering::SeqCst => atomic_load!("a"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        #[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! store {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from val to val pair
+                                "ldrd r2, r3, [{val}]",
+                                // (atomic) store val pair to dst (LL/SC loop)
+                                "2:",
+                                    // load from dst to tmp pair
+                                    concat!("ld", $acquire, "exd r4, r5, [{dst}]"),
+                                    // try to store val pair to dst
+                                    concat!("st", $release, "exd {r}, r2, r3, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, 0x0",
+                                    "bne 2b",
+                                dst = inout(reg) dst => _,
+                                val = in(reg) val,
+                                r = lateout(reg) _,
+                                // val pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // tmp pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(store, order);
+                }
+            }
+        }
+        #[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from val to val pair
+                                "ldrd r2, r3, [{val}]",
+                                // (atomic) swap (LL/SC loop)
+                                "2:",
+                                    // load from dst to out pair
+                                    concat!("ld", $acquire, "exd r4, r5, [{dst}]"),
+                                    // try to store val pair to dst
+                                    concat!("st", $release, "exd {r}, r2, r3, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, 0x0",
+                                    "bne 2b",
+                                // store out pair to out
+                                "strd r4, r5, [{out}]",
+                                dst = inout(reg) dst => _,
+                                val = in(reg) val,
+                                out = inout(reg) out_ptr => _,
+                                r = lateout(reg) _,
+                                // val pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // out pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                                // Do not use `preserves_flags` because CMP modifies the condition flags.
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        #[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32;
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                "ldrd r2, r3, [{old}]",
+                                "ldrd r8, r9, [{new}]",
+                                // (atomic) CAS (LL/SC loop)
+                                "2:",
+                                    concat!("ld", $acquire, "exd r4, r5, [{dst}]"),
+                                    "eor {tmp}, r5, r3",
+                                    "eor {r}, r4, r2",
+                                    "orrs {r}, {r}, {tmp}",
+                                    "bne 3f", // jump if compare failed
+                                    concat!("st", $release, "exd  {r}, r8, r9, [{dst}]"),
+                                    // 0 if the store was successful, 1 if no store was performed
+                                    "cmp {r}, #0",
+                                    "bne 2b", // continue loop if store failed
+                                    "b 4f",
+                                "3:",
+                                    // compare failed, mark r as failed and clear exclusive
+                                    "clrex",
+                                    s!("mov", "{r}, #1"),
+                                "4:",
+                                // store out pair to out
+                                "strd r4, r5, [{out}]",
+                                dst = inout(reg) dst => _,
+                                r = lateout(reg) r,
+                                old = in(reg) old,
+                                new = in(reg) new,
+                                out = inout(reg) out_ptr => _,
+                                tmp = out(reg) _,
+                                // old pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // out pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                                // new pair - must be even-numbered and not R14
+                                out("r8") _,
+                                out("r9") _,
+                                // Do not use `preserves_flags` because CMP, ORRS, and s! modify the condition flags.
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg, order);
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+            #[inline]
+            unsafe fn atomic_compare_exchange_weak(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32;
+                    macro_rules! cmpxchg_weak {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                "ldrd r2, r3, [{old}]",
+                                "ldrd r8, r9, [{new}]",
+                                concat!("ld", $acquire, "exd r4, r5, [{dst}]"),
+                                "eor {tmp}, r5, r3",
+                                "eor {r}, r4, r2",
+                                "orrs {r}, {r}, {tmp}",
+                                "bne 3f", // jump if compare failed
+                                concat!("st", $release, "exd  {r}, r8, r9, [{dst}]"),
+                                "b 4f",
+                                "3:",
+                                    // compare failed, mark r as failed and clear exclusive
+                                    "clrex",
+                                    s!("mov", "{r}, #1"),
+                                "4:",
+                                // store out pair to out
+                                "strd r4, r5, [{out}]",
+                                dst = inout(reg) dst => _,
+                                r = lateout(reg) r,
+                                old = in(reg) old,
+                                new = in(reg) new,
+                                out = inout(reg) out_ptr => _,
+                                tmp = out(reg) _,
+                                // old pair - must be even-numbered and not R14
+                                out("r2") _,
+                                out("r3") _,
+                                // out pair - must be even-numbered and not R14
+                                out("r4") _,
+                                out("r5") _,
+                                // new pair - must be even-numbered and not R14
+                                out("r8") _,
+                                out("r9") _,
+                                // Do not use `preserves_flags` because ORRS and s! modify the condition flags.
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg_weak, order);
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    // 0 if the store was successful, 1 if no store was performed
+                    (out, r == 0)
+                }
+            }
+        }
+    };
+}
+
+atomic64!(i64);
+atomic64!(u64);
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass"))]
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass"))]
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(not(any(target_feature = "mclass", atomic_maybe_uninit_target_feature = "mclass")))]
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}

--- a/src/arch_legacy/hexagon.rs
+++ b/src/arch_legacy/hexagon.rs
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Hexagon
+//
+// Refs:
+// - Hexagon V5x Programmer's Reference Manual
+//   https://developer.qualcomm.com/download/hexagon/hexagon-v5x-programmers-reference-manual.pdf?referrer=node/6116
+
+#[path = "../arch/partword.rs"]
+mod partword;
+
+use core::{arch::asm, mem::MaybeUninit, sync::atomic::Ordering};
+
+use crate::raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap};
+
+type XSize = usize;
+
+macro_rules! atomic_load_store {
+    ($int_type:ident, $asm_suffix:tt, $asm_u_suffix:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        // (atomic) load from src to tmp
+                        concat!("{tmp} = mem", $asm_u_suffix, $asm_suffix, "({src})"),
+                        // store tmp to out
+                        concat!("mem", $asm_suffix, "({out}) = {tmp}"),
+                        src = in(reg) src,
+                        out = inout(reg) out_ptr => _,
+                        tmp = lateout(reg) _,
+                        options(nostack, preserves_flags),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) {
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        // load from val to tmp
+                        concat!("{tmp} = mem", $asm_u_suffix, $asm_suffix, "({val})"),
+                        // (atomic) store tmp to dst
+                        concat!("mem", $asm_suffix, "({dst}) = {tmp}"),
+                        dst = inout(reg) dst => _,
+                        val = in(reg) val,
+                        tmp = lateout(reg) _,
+                        options(nostack, preserves_flags),
+                    );
+                }
+            }
+        }
+    };
+}
+
+macro_rules! atomic {
+    ($int_type:ident) => {
+        atomic_load_store!($int_type, "w", "");
+        impl AtomicSwap for $int_type {
+            #[inline(never)] // TODO: there is no way to mark p0 as clobbered
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        "{val} = memw({val})",
+                        "2:",
+                            "{tmp} = memw_locked({dst})",
+                            "memw_locked({dst},p0) = {val}",
+                            "if (!p0) jump 2b",
+                        "memw({out}) = {tmp}",
+                        dst = in(reg) dst,
+                        val = inout(reg) val => _,
+                        out = in(reg) out_ptr,
+                        tmp = out(reg) _,
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline(never)] // TODO: there is no way to mark p0 as clobbered
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32 = 1;
+                    asm!(
+                        "{old} = memw({old})",
+                        "{new} = memw({new})",
+                        "2:",
+                            "{tmp} = memw_locked({dst})",
+                            "{{ p0 = cmp.eq({tmp},{old})",
+                                "if (!p0.new) jump:nt 3f }}",
+                            "memw_locked({dst},p0) = {new}",
+                            "if (!p0) jump 2b",
+                            "jump 4f",
+                        "3:",
+                            "{r} = #0",
+                        "4:",
+                        "memw({out}) = {tmp}",
+                        dst = in(reg) dst,
+                        old = inout(reg) old => _,
+                        new = inout(reg) new => _,
+                        out = in(reg) out_ptr,
+                        tmp = out(reg) _,
+                        r = inout(reg) r,
+                        options(nostack),
+                    );
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+macro_rules! atomic_sub_word {
+    ($int_type:ident, $asm_suffix:tt, $asm_u_suffix:tt) => {
+        atomic_load_store!($int_type, $asm_suffix, $asm_u_suffix);
+        impl AtomicSwap for $int_type {
+            #[inline(never)] // TODO: there is no way to mark p0 as clobbered
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        concat!("{val} = mem", $asm_u_suffix, $asm_suffix, "({val})"),
+                        "{mask} = asl({mask},{shift})",
+                        "{val} = asl({val},{shift})",
+                        "{val} = and({val},{mask})",
+                        "{inv_mask} = not({mask})",
+                        "2:",
+                            "{out_tmp} = memw_locked({dst})",
+                            "{tmp} = and({out_tmp},{inv_mask})",
+                            "{tmp} = or({tmp},{val})",
+                            "memw_locked({dst},p0) = {tmp}",
+                            "if (!p0) jump 2b",
+                        "{out_tmp} = asr({out_tmp},{shift})",
+                        concat!("mem", $asm_suffix, "({out}) = {out_tmp}"),
+                        dst = in(reg) aligned_ptr,
+                        val = inout(reg) val => _,
+                        out = in(reg) out_ptr,
+                        shift = in(reg) shift,
+                        mask = inout(reg) mask => _,
+                        inv_mask = out(reg) _,
+                        out_tmp = out(reg) _,
+                        tmp = out(reg) _,
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline(never)] // TODO: there is no way to mark p0 as clobbered
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32 = 1;
+                    asm!(
+                        concat!("{old} = mem", $asm_u_suffix, $asm_suffix, "({old})"),
+                        concat!("{new} = mem", $asm_u_suffix, $asm_suffix, "({new})"),
+                        "{mask} = asl({mask},{shift})",
+                        "{old} = asl({old},{shift})",
+                        "{new} = asl({new},{shift})",
+                        "{old} = and({old},{mask})",
+                        "{new} = and({new},{mask})",
+                        "{inv_mask} = not({mask})",
+                        "2:",
+                            "{tmp} = memw_locked({dst})",
+                            "{out_tmp} = and({tmp},{mask})",
+                            "{{ p0 = cmp.eq({out_tmp},{old})",
+                                "if (!p0.new) jump:nt 3f }}",
+                            "{tmp} = and({tmp},{inv_mask})",
+                            "{tmp} = or({tmp},{new})",
+                            "memw_locked({dst},p0) = {tmp}",
+                            "if (!p0) jump 2b",
+                            "jump 4f",
+                        "3:",
+                            "{r} = #0",
+                        "4:",
+                        "{out_tmp} = asr({out_tmp},{shift})",
+                        concat!("mem", $asm_suffix, "({out}) = {out_tmp}"),
+                        dst = in(reg) aligned_ptr,
+                        old = inout(reg) old => _,
+                        new = inout(reg) new => _,
+                        out = in(reg) out_ptr,
+                        shift = in(reg) shift,
+                        mask = inout(reg) mask => _,
+                        inv_mask = out(reg) _,
+                        out_tmp = out(reg) _,
+                        tmp = out(reg) _,
+                        r = inout(reg) r,
+                        options(nostack),
+                    );
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+atomic_sub_word!(i8, "b", "u");
+atomic_sub_word!(u8, "b", "u");
+atomic_sub_word!(i16, "h", "u");
+atomic_sub_word!(u16, "h", "u");
+atomic!(i32);
+atomic!(u32);
+atomic!(isize);
+atomic!(usize);
+
+macro_rules! atomic64 {
+    ($int_type:ident) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        // (atomic) load from src to tmp pair
+                        "{{ r3:2 = memd({src}) }}",
+                        // store tmp pair to out
+                        "memd({out}) = r3:2",
+                        src = in(reg) src,
+                        out = in(reg) out_ptr,
+                        out("r2") _, // tmp
+                        out("r3") _, // tmp
+                        options(nostack, preserves_flags),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) {
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        // load from val to tmp pair
+                        "{{ r3:2 = memd({val}) }}",
+                        // (atomic) store tmp pair to dst
+                        "memd({dst}) = r3:2",
+                        dst = in(reg) dst,
+                        val = in(reg) val,
+                        out("r2") _, // tmp
+                        out("r3") _, // tmp
+                        options(nostack, preserves_flags),
+                    );
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline(never)] // TODO: there is no way to mark p0 as clobbered
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        "{{ r3:2 = memd({val}) }}",
+                        "2:",
+                            "{{ r5:4 = memd_locked({dst}) }}",
+                            "memd_locked({dst},p0) = r3:2",
+                            "if (!p0) jump 2b",
+                        "memd({out}) = r5:4",
+                        dst = in(reg) dst,
+                        val = in(reg) val,
+                        out = in(reg) out_ptr,
+                        out("r2") _, // val
+                        out("r3") _, // val
+                        out("r4") _, // tmp
+                        out("r5") _, // tmp
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline(never)] // TODO: there is no way to mark p0 as clobbered
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i32 = 1;
+                    asm!(
+                        "{{ r3:2 = memd({old}) }}",
+                        "{{ r5:4 = memd({new}) }}",
+                        "2:",
+                            "{{ r7:6 = memd_locked({dst}) }}",
+                            // TODO: merge two cmp?
+                            "{{ p0 = cmp.eq(r6,r2)",
+                                "if (!p0.new) jump:nt 3f }}",
+                            "{{ p0 = cmp.eq(r7,r3)",
+                                "if (!p0.new) jump:nt 3f }}",
+                            "memd_locked({dst},p0) = r5:4",
+                            "if (!p0) jump 2b",
+                            "jump 4f",
+                        "3:",
+                            "{r} = #0",
+                        "4:",
+                        "memd({out}) = r7:6",
+                        dst = in(reg) dst,
+                        old = in(reg) old,
+                        new = in(reg) new,
+                        out = in(reg) out_ptr,
+                        r = inout(reg) r,
+                        out("r2") _, // old
+                        out("r3") _, // old
+                        out("r4") _, // new
+                        out("r5") _, // new
+                        out("r6") _, // tmp
+                        out("r7") _, // tmp
+                        options(nostack),
+                    );
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+atomic64!(i64);
+atomic64!(u64);
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}

--- a/src/arch_legacy/loongarch.rs
+++ b/src/arch_legacy/loongarch.rs
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// LoongArch
+//
+// Generated asm:
+// - loongarch64 https://godbolt.org/z/vTxfajT14
+
+#[path = "../arch/partword.rs"]
+mod partword;
+
+use core::{
+    arch::asm,
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+use crate::raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap};
+
+#[cfg(target_arch = "loongarch64")]
+type XSize = u64;
+
+#[rustfmt::skip]
+macro_rules! atomic_load {
+    ($int_type:ident, $asm_suffix:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load {
+                        ($acquire:tt) => {
+                            asm!(
+                                // (atomic) load from src to tmp
+                                concat!("ld.", $asm_suffix, " {tmp}, {src}, 0"),
+                                $acquire,
+                                // store tmp to out
+                                concat!("st.", $asm_suffix, " {tmp}, {out}, 0"),
+                                src = in(reg) ptr_reg!(src),
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!(""),
+                        // Acquire and SeqCst loads are equivalent.
+                        Ordering::Acquire | Ordering::SeqCst => atomic_load!("dbar 0"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+    };
+}
+
+macro_rules! atomic {
+    ($int_type:ident, $asm_suffix:tt) => {
+        atomic_load!($int_type, $asm_suffix);
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    match order {
+                        Ordering::Relaxed => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("ld.", $asm_suffix, " {tmp}, {val}, 0"),
+                                // (atomic) store tmp to dst
+                                concat!("st.", $asm_suffix, " {tmp}, {dst}, 0"),
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                val = in(reg) ptr_reg!(val),
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            );
+                        }
+                        Ordering::Release | Ordering::SeqCst => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("ld.", $asm_suffix, " {tmp}, {val}, 0"),
+                                // (atomic) store tmp to dst
+                                concat!("amswap_db.", $asm_suffix, " $zero, {tmp}, {dst}"),
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                val = in(reg) ptr_reg!(val),
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        }
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    asm!(
+                        // load from val (ptr) to val (val)
+                        concat!("ld.", $asm_suffix, " {val}, {val}, 0"),
+                        // (atomic) swap (AMO)
+                        // - load value from dst and store it to tmp
+                        // - store value of val to dst
+                        concat!("amswap_db.", $asm_suffix, " {tmp}, {val}, {dst}"),
+                        // store tmp to out
+                        concat!("st.", $asm_suffix, " {tmp}, {out}, 0"),
+                        dst = in(reg) ptr_reg!(dst),
+                        val = inout(reg) ptr_reg!(val) => _,
+                        out = inout(reg) ptr_reg!(out_ptr) => _,
+                        tmp = out(reg) _,
+                        options(nostack, preserves_flags),
+                    )
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: XSize;
+                    asm!(
+                        // load from old/new (ptr) to old/new (val)
+                        concat!("ld.", $asm_suffix, " {old}, {old}, 0"),
+                        concat!("ld.", $asm_suffix, " {new}, {new}, 0"),
+                        // (atomic) CAS (LL/SC loop)
+                        "2:",
+                            concat!("ll.", $asm_suffix, " {tmp}, {dst}, 0"),
+                            "bne {tmp}, {old}, 3f", // compare and jump if compare failed
+                            "dbar 0",
+                            "move {r}, {new}",
+                            concat!("sc.", $asm_suffix, " {r}, {dst}, 0"),
+                            "beqz {r}, 2b", // continue loop if store failed
+                            "b 4f",
+                        "3:",
+                            "dbar 1792",
+                        "4:",
+                        // store tmp to out
+                        concat!("st.", $asm_suffix, " {tmp}, {out}, 0"),
+                        "xor {r}, {tmp}, {old}",
+                        "sltui {r}, {r}, 1",
+                        dst = in(reg) ptr_reg!(dst),
+                        old = inout(reg) ptr_reg!(old) => _,
+                        new = inout(reg) ptr_reg!(new) => _,
+                        out = in(reg) ptr_reg!(out_ptr),
+                        tmp = out(reg) _,
+                        r = out(reg) r,
+                        options(nostack, preserves_flags),
+                    );
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+macro_rules! atomic_sub_word {
+    ($int_type:ident, $asm_suffix:tt) => {
+        atomic_load!($int_type, $asm_suffix);
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("ld.", $asm_suffix, " {tmp}, {val}, 0"),
+                                // (atomic) store tmp to dst
+                                $release,
+                                concat!("st.", $asm_suffix, " {tmp}, {dst}, 0"),
+                                $acquire,
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                val = in(reg) ptr_reg!(val),
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_store!("", ""),
+                        Ordering::Release => atomic_store!("", "dbar 0"),
+                        Ordering::SeqCst => atomic_store!("dbar 0", "dbar 0"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // Implement sub-word atomic operations using word-sized LL/SC loop.
+                    // Based on assemblies generated by rustc/LLVM.
+                    // See also partword.rs.
+                    macro_rules! atomic_swap {
+                        ($fence:tt) => {
+                            asm!(
+                                "sll.w {mask}, {mask}, {shift}",
+                                "addi.w {mask}, {mask}, 0",
+                                concat!("ld.", $asm_suffix, "u {val}, {val}, 0"),
+                                "sll.w {val}, {val}, {shift}",
+                                "addi.w {val}, {val}, 0",
+                                // (atomic) swap (LL/SC loop)
+                                "2:",
+                                    $fence,
+                                    "ll.w {tmp1}, {dst}, 0",
+                                    "addi.w {tmp2}, {val}, 0",
+                                    "xor {tmp2}, {tmp1}, {tmp2}",
+                                    "and {tmp2}, {tmp2}, {mask}",
+                                    "xor {tmp2}, {tmp1}, {tmp2}",
+                                    "sc.w {tmp2}, {dst}, 0",
+                                    "beqz {tmp2}, 2b",
+                                "srl.w {tmp1}, {tmp1}, {shift}",
+                                concat!("st.", $asm_suffix, " {tmp1}, {out}, 0"),
+                                dst = in(reg) ptr_reg!(aligned_ptr),
+                                val = inout(reg) ptr_reg!(val) => _,
+                                out = in(reg) ptr_reg!(out_ptr),
+                                shift = in(reg) shift,
+                                mask = inout(reg) mask => _,
+                                tmp1 = out(reg) _,
+                                tmp2 = out(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_swap!(""),
+                        _ => atomic_swap!("dbar 0"),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: XSize;
+                    // Implement sub-word atomic operations using word-sized LL/SC loop.
+                    // Based on assemblies generated by rustc/LLVM.
+                    // See also partword.rs.
+                    asm!(
+                        concat!("ld.", $asm_suffix, "u {new}, {new}, 0"),
+                        concat!("ld.", $asm_suffix, "u {old}, {old}, 0"),
+                        "sll.w {new}, {new}, {shift}",
+                        "addi.w {new}, {new}, 0",
+                        "sll.w {old}, {old}, {shift}",
+                        "addi.w $a7, {old}, 0",
+                        "sll.w {mask}, {mask}, {shift}",
+                        "addi.w $a6, {mask}, 0",
+                        // (atomic) CAS (LL/SC loop)
+                        "2:",
+                            "ll.w $t0, {dst}, 0",
+                            "and $t1, $t0, $a6",
+                            "bne $t1, $a7, 3f",
+                            "dbar 0",
+                            "andn $t1, $t0, $a6",
+                            "or $t1, $t1, {new}",
+                            "sc.w $t1, {dst}, 0",
+                            "beqz $t1, 2b",
+                            "b 4f",
+                        "3:",
+                            "dbar 1792",
+                        "4:",
+                        "srl.w $a6, $t0, {shift}",
+                        concat!("st.", $asm_suffix, " $a6, {out}, 0"),
+                        "and {r}, $t0, {mask}",
+                        "addi.w {r}, {r}, 0",
+                        "xor {r}, {old}, {r}",
+                        "sltui {r}, {r}, 1",
+                        dst = in(reg) ptr_reg!(aligned_ptr),
+                        old = inout(reg) ptr_reg!(old) => _,
+                        new = inout(reg) ptr_reg!(new) => _,
+                        out = inout(reg) ptr_reg!(out_ptr) => _,
+                        shift = in(reg) shift,
+                        mask = inout(reg) mask => _,
+                        r = lateout(reg) r,
+                        out("$a6") _,
+                        out("$a7") _,
+                        out("$t0") _,
+                        out("$t1") _,
+                        options(nostack, preserves_flags),
+                    );
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+atomic_sub_word!(i8, "b");
+atomic_sub_word!(u8, "b");
+atomic_sub_word!(i16, "h");
+atomic_sub_word!(u16, "h");
+atomic!(i32, "w");
+atomic!(u32, "w");
+#[cfg(target_arch = "loongarch64")]
+atomic!(i64, "d");
+#[cfg(target_arch = "loongarch64")]
+atomic!(u64, "d");
+#[cfg(target_pointer_width = "32")]
+atomic!(isize, "w");
+#[cfg(target_pointer_width = "32")]
+atomic!(usize, "w");
+#[cfg(target_pointer_width = "64")]
+atomic!(isize, "d");
+#[cfg(target_pointer_width = "64")]
+atomic!(usize, "d");
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}

--- a/src/arch_legacy/mips.rs
+++ b/src/arch_legacy/mips.rs
@@ -1,0 +1,465 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// MIPS32 and MIPS64
+//
+// Generated asm:
+// - mips https://godbolt.org/z/38oKcY5bj
+// - mipsel https://godbolt.org/z/M18x694zh
+// - mips64 https://godbolt.org/z/GMMda9rM8
+// - mips64el https://godbolt.org/z/31ovT3vzW
+
+#[path = "../arch/partword.rs"]
+mod partword;
+
+use core::{
+    arch::asm,
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+use crate::raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap};
+
+// TODO: we can add options(preserves_flags) to some of asm!
+
+macro_rules! atomic_rmw {
+    ($op:ident, $order:ident) => {
+        match $order {
+            Ordering::Relaxed => $op!("", ""),
+            Ordering::Acquire => $op!("sync", ""),
+            Ordering::Release => $op!("", "sync"),
+            // AcqRel and SeqCst RMWs are equivalent.
+            Ordering::AcqRel | Ordering::SeqCst => $op!("sync", "sync"),
+            _ => unreachable!("{:?}", $order),
+        }
+    };
+}
+
+#[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+type XSize = u32;
+#[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+type XSize = u64;
+
+#[rustfmt::skip]
+macro_rules! atomic_load_store {
+    ($int_type:ident, $asm_suffix:tt, $l_u_suffix:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load {
+                        ($acquire:tt) => {
+                            asm!(
+                                ".set push",
+                                ".set noat",
+                                // (atomic) load from src to tmp
+                                concat!("l", $asm_suffix, " {tmp}, 0({src})"),
+                                $acquire,
+                                // store tmp to out
+                                concat!("s", $asm_suffix, " {tmp}, 0({out})"),
+                                ".set pop",
+                                src = in(reg) ptr_reg!(src),
+                                out = in(reg) ptr_reg!(out_ptr),
+                                tmp = out(reg) _,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!(""),
+                        // Acquire and SeqCst loads are equivalent.
+                        Ordering::Acquire | Ordering::SeqCst => atomic_load!("sync"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! store {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                ".set push",
+                                ".set noat",
+                                // load from val to tmp
+                                concat!("l", $asm_suffix, $l_u_suffix, " {tmp}, 0({val})"),
+                                // (atomic) store tmp to dst
+                                $release, // release fence
+                                concat!("s", $asm_suffix, " {tmp}, 0({dst})"),
+                                $acquire, // acquire fence
+                                ".set pop",
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(reg) ptr_reg!(val),
+                                tmp = out(reg) _,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(store, order);
+                }
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! atomic {
+    ($int_type:ident, $asm_suffix:tt, $ll_sc_suffix:tt) => {
+        atomic_load_store!($int_type, $asm_suffix, "");
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                ".set push",
+                                ".set noat",
+                                // load from val to val_tmp
+                                concat!("l", $asm_suffix, " {val_tmp}, 0({val})"),
+                                // (atomic) swap (LL/SC loop)
+                                $release, // release fence
+                                "2:",
+                                    // load from dst to out_tmp
+                                    concat!("ll", $ll_sc_suffix, " {out_tmp}, 0({dst})"),
+                                    "move {r}, {val_tmp}",
+                                    // try to store val to dst
+                                    concat!("sc", $ll_sc_suffix, " {r}, 0({dst})"),
+                                    // 1 if the store was successful, 0 if no store was performed
+                                    "beqz {r}, 2b",
+                                $acquire, // acquire fence
+                                // store out_tmp to out
+                                concat!("s", $asm_suffix, " {out_tmp}, 0({out})"),
+                                ".set pop",
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                val = in(reg) ptr_reg!(val),
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                val_tmp = out(reg) _,
+                                out_tmp = out(reg) _,
+                                r = lateout(reg) _,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: XSize;
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                ".set push",
+                                ".set noat",
+                                // load from old/new to old_tmp/new_tmp
+                                concat!("l", $asm_suffix, " {old_tmp}, 0({old})"),
+                                concat!("l", $asm_suffix, " {new_tmp}, 0({new})"),
+                                // (atomic) CAS (LL/SC loop)
+                                $release, // release fence
+                                "2:",
+                                    // load from dst to out_tmp
+                                    concat!("ll", $ll_sc_suffix, " {out_tmp}, 0({dst})"),
+                                    "bne {out_tmp}, {old_tmp}, 3f", // compare and jump if compare failed
+                                    "move {r}, {new_tmp}",
+                                    // try to store new to dst
+                                    concat!("sc", $ll_sc_suffix, " {r}, 0({dst})"),
+                                    // 1 if the store was successful, 0 if no store was performed
+                                    "beqz {r}, 2b", // continue loop if store failed
+                                "3:",
+                                $acquire, // acquire fence
+                                "xor {new_tmp}, {out_tmp}, {old_tmp}",
+                                // store out_tmp to out
+                                concat!("s", $asm_suffix, " {out_tmp}, 0({out})"),
+                                "sltiu {r}, {new_tmp}, 1",
+                                ".set pop",
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                old = in(reg) ptr_reg!(old),
+                                new = in(reg) ptr_reg!(new),
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                new_tmp = out(reg) _,
+                                old_tmp = out(reg) _,
+                                out_tmp = out(reg) _,
+                                r = lateout(reg) r,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg, order);
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! atomic_sub_word {
+    ($int_type:ident, $asm_suffix:tt, $max:tt) => {
+        atomic_load_store!($int_type, $asm_suffix, "u");
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // Implement sub-word atomic operations using word-sized LL/SC loop.
+                    // Based on assemblies generated by rustc/LLVM.
+                    // See also partword.rs.
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                ".set push",
+                                ".set noat",
+                                concat!("l", $asm_suffix, "u {tmp}, 0($5)"),
+                                "sllv {mask}, {mask}, {shift}",
+                                "sllv $7, {tmp}, {shift}",
+                                "nor $5, $zero, {mask}",
+                                // (atomic) swap (LL/SC loop)
+                                $release,
+                                "2:",
+                                    "ll $8, 0({dst})",
+                                    "and $9, $7, {mask}",
+                                    "and $10, $8, $5",
+                                    "or $10, $10, $9",
+                                    "sc $10, 0({dst})",
+                                    "beqz $10, 2b",
+                                "and {tmp}, $8, {mask}",
+                                "srlv {tmp}, {tmp}, {shift}",
+                                concat!("se", $asm_suffix, " {tmp}, {tmp}"),
+                                $acquire,
+                                concat!("s", $asm_suffix, " {tmp}, 0({out})"),
+                                ".set pop",
+                                dst = in(reg) ptr_reg!(aligned_ptr),
+                                out = in(reg) ptr_reg!(out_ptr),
+                                shift = in(reg) shift,
+                                mask = inout(reg) mask => _,
+                                tmp = out(reg) _,
+                                inout("$5") ptr_reg!(val) => _, // val => inv_mask
+                                out("$7") _,
+                                out("$8") _,
+                                out("$9") _,
+                                out("$10") _,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let (aligned_ptr, shift, _mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: XSize;
+                    // Implement sub-word atomic operations using word-sized LL/SC loop.
+                    // Based on assemblies generated by rustc/LLVM.
+                    // See also partword.rs.
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                ".set push",
+                                ".set noat",
+                                concat!("l", $asm_suffix, "u $2, 0($6)"), // new
+                                concat!("l", $asm_suffix, " {tmp}, 0($5)"),  // old
+                                concat!("ori $5, $zero, ", $max),
+                                concat!("andi $8, {tmp}, ", $max),
+                                concat!("andi $2, $2, ", $max),
+                                "sllv $5, $5, {shift}",
+                                "sllv $8, $8, {shift}",
+                                "sllv $9, $2, {shift}",
+                                "nor $6, $zero, $5",
+                                // (atomic) CAS (LL/SC loop)
+                                $release,
+                                "2:",
+                                    "ll $10, 0({dst})",
+                                    "and $11, $10, $5",
+                                    "bne $11, $8, 3f",
+                                    "and $10, $10, $6",
+                                    "or $10, $10, $9",
+                                    "sc $10, 0({dst})",
+                                    "beqz $10, 2b",
+                                "3:",
+                                "srlv $2, $11, {shift}",
+                                concat!("se", $asm_suffix, " $2, $2"),
+                                $acquire,
+                                "xor {tmp}, $2, {tmp}",
+                                concat!("s", $asm_suffix, " $2, 0({out})"),
+                                "sltiu $2, {tmp}, 1",
+                                ".set pop",
+                                dst = in(reg) ptr_reg!(aligned_ptr),
+                                out = in(reg) ptr_reg!(out_ptr),
+                                shift = in(reg) shift,
+                                tmp = out(reg) _,
+                                out("$2") r,
+                                inout("$5") ptr_reg!(old) => _, // old => mask
+                                inout("$6") ptr_reg!(new) => _, // new => inv_mask
+                                out("$8") _,
+                                out("$9") _,
+                                out("$10") _,
+                                out("$11") _,
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg, order);
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+atomic_sub_word!(i8, "b", "255");
+atomic_sub_word!(u8, "b", "255");
+atomic_sub_word!(i16, "h", "65535");
+atomic_sub_word!(u16, "h", "65535");
+atomic!(i32, "w", "");
+atomic!(u32, "w", "");
+#[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+atomic!(i64, "d", "d");
+#[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+atomic!(u64, "d", "d");
+#[cfg(target_pointer_width = "32")]
+atomic!(isize, "w", "");
+#[cfg(target_pointer_width = "32")]
+atomic!(usize, "w", "");
+#[cfg(target_pointer_width = "64")]
+atomic!(isize, "d", "d");
+#[cfg(target_pointer_width = "64")]
+atomic!(usize, "d", "d");
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}

--- a/src/arch_legacy/msp430.rs
+++ b/src/arch_legacy/msp430.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// MSP430
+//
+// Refs: https://www.ti.com/lit/ug/slau208q/slau208q.pdf
+
+use core::{arch::asm, mem::MaybeUninit, sync::atomic::Ordering};
+
+use crate::raw::{AtomicLoad, AtomicStore};
+
+macro_rules! atomic {
+    ($int_type:ident, $asm_suffix:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // atomic load is always SeqCst.
+                    asm!(
+                        // TODO: use mem to mem mov?
+                        // (atomic) load from src to tmp
+                        concat!("mov", $asm_suffix, " @{src}, {tmp}"),
+                        // store tmp to out
+                        concat!("mov", $asm_suffix, " {tmp}, 0({out})"),
+                        src = in(reg) src,
+                        out = inout(reg) out_ptr => _,
+                        tmp = lateout(reg) _,
+                        options(nostack, preserves_flags),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) {
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // atomic store is always SeqCst.
+                    asm!(
+                        // TODO: use mem to mem mov?
+                        // load from val to tmp
+                        concat!("mov", $asm_suffix, " @{val}, {tmp}"),
+                        // (atomic) store tmp to dst
+                        concat!("mov", $asm_suffix, " {tmp}, 0({dst})"),
+                        dst = inout(reg) dst => _,
+                        val = in(reg) val,
+                        tmp = lateout(reg) _,
+                        options(nostack, preserves_flags),
+                    );
+                }
+            }
+        }
+    };
+}
+
+atomic!(i8, ".b");
+atomic!(u8, ".b");
+atomic!(i16, ".w");
+atomic!(u16, ".w");
+atomic!(isize, ".w");
+atomic!(usize, ".w");
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}

--- a/src/arch_legacy/powerpc.rs
+++ b/src/arch_legacy/powerpc.rs
@@ -1,0 +1,870 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// PowerPC and PowerPC64
+//
+// Refs:
+// - Power ISA https://openpowerfoundation.org/specifications/isa
+// - AIX Assembler language reference https://www.ibm.com/docs/en/aix/7.3?topic=aix-assembler-language-reference
+// - http://www.rdrop.com/users/paulmck/scalability/paper/N2745r.2010.02.19a.html
+// - portable-atomic https://github.com/taiki-e/portable-atomic
+//
+// Generated asm:
+// - powerpc https://godbolt.org/z/PME7czo4P
+// - powerpc64 https://godbolt.org/z/forK75PK4
+// - powerpc64 (pwr8) https://godbolt.org/z/eGf47W164
+// - powerpc64le https://godbolt.org/z/7f1b8WWd3
+// - powerpc64le (pwr7) https://godbolt.org/z/bKxv6W3Mn
+
+#[cfg(not(all(
+    target_arch = "powerpc64",
+    any(
+        target_feature = "partword-atomics",
+        atomic_maybe_uninit_target_feature = "partword-atomics",
+    ),
+)))]
+#[path = "../arch/partword.rs"]
+mod partword;
+
+use core::{
+    arch::asm,
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+use crate::raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap};
+
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "quadword-atomics",
+    atomic_maybe_uninit_target_feature = "quadword-atomics",
+))]
+#[cfg(target_endian = "big")]
+macro_rules! p128h {
+    () => {
+        "0"
+    };
+}
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "quadword-atomics",
+    atomic_maybe_uninit_target_feature = "quadword-atomics",
+))]
+#[cfg(target_endian = "big")]
+macro_rules! p128l {
+    () => {
+        "8"
+    };
+}
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "quadword-atomics",
+    atomic_maybe_uninit_target_feature = "quadword-atomics",
+))]
+#[cfg(target_endian = "little")]
+macro_rules! p128h {
+    () => {
+        "8"
+    };
+}
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "quadword-atomics",
+    atomic_maybe_uninit_target_feature = "quadword-atomics",
+))]
+#[cfg(target_endian = "little")]
+macro_rules! p128l {
+    () => {
+        "0"
+    };
+}
+
+macro_rules! atomic_rmw {
+    ($op:ident, $order:ident) => {
+        match $order {
+            Ordering::Relaxed => $op!("", ""),
+            Ordering::Acquire => $op!("lwsync", ""),
+            Ordering::Release => $op!("", "lwsync"),
+            Ordering::AcqRel => $op!("lwsync", "lwsync"),
+            Ordering::SeqCst => $op!("lwsync", "sync"),
+            _ => unreachable!("{:?}", $order),
+        }
+    };
+}
+
+#[cfg(target_arch = "powerpc")]
+type XSize = u32;
+#[cfg(target_arch = "powerpc64")]
+type XSize = u64;
+
+use XSize as Cr;
+// Extracts and checks the EQ bit of cr0.
+#[inline]
+fn extract_cr0(r: Cr) -> bool {
+    r & 0x20000000 != 0
+}
+
+#[rustfmt::skip]
+macro_rules! atomic_load_store {
+    ($int_type:ident, $l_suffix:tt, $asm_suffix:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // (atomic) load from src to tmp
+                                $release,
+                                concat!("l", $l_suffix, " {tmp}, 0({src})"),
+                                $acquire,
+                                // store tmp to out
+                                concat!("st", $asm_suffix, " {tmp}, 0({out})"),
+                                src = in(reg_nonzero) ptr_reg!(src),
+                                out = inout(reg_nonzero) ptr_reg!(out_ptr) => _,
+                                tmp = lateout(reg_nonzero) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    #[cfg(target_arch = "powerpc64")]
+                    macro_rules! atomic_load_acquire {
+                        ($release:tt) => {
+                            asm!(
+                                $release,
+                                // (atomic) load from src to tmp
+                                concat!("l", $l_suffix, " {tmp}, 0({src})"),
+                                // Lightweight acquire sync
+                                // Refs: https://github.com/boostorg/atomic/blob/boost-1.79.0/include/boost/atomic/detail/core_arch_ops_gcc_ppc.hpp#L47-L62
+                                "cmpd %cr7, {tmp}, {tmp}",
+                                "bne- %cr7, 2f",
+                                "2:",
+                                "isync",
+                                // store tmp to out
+                                concat!("st", $asm_suffix, " {tmp}, 0({out})"),
+                                src = in(reg_nonzero) ptr_reg!(src),
+                                out = inout(reg_nonzero) ptr_reg!(out_ptr) => _,
+                                tmp = lateout(reg_nonzero) _,
+                                out("cr7") _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!("", ""),
+                        #[cfg(target_arch = "powerpc64")]
+                        Ordering::Acquire => atomic_load_acquire!(""),
+                        #[cfg(target_arch = "powerpc64")]
+                        Ordering::SeqCst => atomic_load_acquire!("sync"),
+                        #[cfg(target_arch = "powerpc")]
+                        Ordering::Acquire => atomic_load!("lwsync", ""),
+                        #[cfg(target_arch = "powerpc")]
+                        Ordering::SeqCst => atomic_load!("lwsync", "sync"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($release:tt) => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("l", $l_suffix, " {tmp}, 0({val})"),
+                                // (atomic) store tmp to dst
+                                $release,
+                                concat!("st", $asm_suffix, " {tmp}, 0({dst})"),
+                                dst = inout(reg_nonzero) ptr_reg!(dst) => _,
+                                val = in(reg_nonzero) ptr_reg!(val),
+                                tmp = lateout(reg_nonzero) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_store!(""),
+                        Ordering::Release => atomic_store!("lwsync"),
+                        Ordering::SeqCst => atomic_store!("sync"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! atomic {
+    ($int_type:ident, $l_suffix:tt, $asm_suffix:tt, $cmp_suffix:tt) => {
+        atomic_load_store!($int_type, $l_suffix, $asm_suffix);
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from val (ptr) to val (val)
+                                concat!("l", $l_suffix, " {val}, 0({val})"),
+                                // (atomic) swap (LL/SC loop)
+                                $release,
+                                "2:",
+                                    // load from dst to tmp
+                                    concat!("l", $asm_suffix, "arx {tmp}, 0, {dst}"),
+                                    // try to store val to dst
+                                    concat!("st", $asm_suffix, "cx. {val}, 0, {dst}"),
+                                    "bne %cr0, 2b",
+                                $acquire,
+                                // store tmp to out
+                                concat!("st", $asm_suffix, " {tmp}, 0({out})"),
+                                dst = in(reg_nonzero) ptr_reg!(dst),
+                                val = inout(reg_nonzero) ptr_reg!(val) => _,
+                                out = in(reg_nonzero) ptr_reg!(out_ptr),
+                                tmp = out(reg_nonzero) _,
+                                out("cr0") _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: Cr;
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from old/new (ptr) to old/new (val)
+                                concat!("l", $l_suffix, " {old}, 0({old})"),
+                                concat!("l", $l_suffix, " {new}, 0({new})"),
+                                // (atomic) CAS (LL/SC loop)
+                                $release,
+                                "2:",
+                                    concat!("l", $asm_suffix, "arx {tmp}, 0, {dst}"),
+                                    concat!("cmp", $cmp_suffix, " {old}, {tmp}"),
+                                    "bne %cr0, 3f", // jump if compare failed
+                                    concat!("st", $asm_suffix, "cx. {new}, 0, {dst}"),
+                                    "bne %cr0, 2b", // continue loop if store failed
+                                "3:",
+                                // if compare failed EQ bit is cleared, if stqcx succeeds EQ bit is set.
+                                "mfcr {r}",
+                                $acquire,
+                                // store tmp to out
+                                concat!("st", $asm_suffix, " {tmp}, 0({out})"),
+                                dst = in(reg_nonzero) ptr_reg!(dst),
+                                old = inout(reg_nonzero) ptr_reg!(old) => _,
+                                new = inout(reg_nonzero) ptr_reg!(new) => _,
+                                out = inout(reg_nonzero) ptr_reg!(out_ptr) => _,
+                                tmp = out(reg_nonzero) _,
+                                r = lateout(reg_nonzero) r,
+                                out("cr0") _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg, order);
+                    (out, extract_cr0(r))
+                }
+            }
+        }
+    };
+}
+
+#[cfg(not(all(
+    target_arch = "powerpc64",
+    any(
+        target_feature = "partword-atomics",
+        atomic_maybe_uninit_target_feature = "partword-atomics",
+    ),
+)))]
+#[rustfmt::skip]
+macro_rules! atomic_sub_word {
+    ($int_type:ident, $l_suffix:tt, $asm_suffix:tt) => {
+        atomic_load_store!($int_type, $l_suffix, $asm_suffix);
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // Implement sub-word atomic operations using word-sized LL/SC loop.
+                    // Based on assemblies generated by rustc/LLVM.
+                    // See also partword.rs.
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                concat!("l", $l_suffix, " {val}, 0({val})"),
+                                "slw {mask}, {mask}, {shift}",
+                                "slw {val}, {val}, {shift}",
+                                "and {val}, {val}, {mask}",
+                                // (atomic) swap (LL/SC loop)
+                                $release,
+                                "2:",
+                                    "lwarx {tmp1}, 0, {dst}",
+                                    "andc {tmp2}, {tmp1}, {mask}",
+                                    "or {tmp2}, {val}, {tmp2}",
+                                    "stwcx. {tmp2}, 0, {dst}",
+                                    "bne %cr0, 2b",
+                                "srw {tmp1}, {tmp1}, {shift}",
+                                $acquire,
+                                concat!("st", $asm_suffix, " {tmp1}, 0({out})"),
+                                dst = in(reg_nonzero) ptr_reg!(aligned_ptr),
+                                val = inout(reg_nonzero) ptr_reg!(val) => _,
+                                out = in(reg_nonzero) ptr_reg!(out_ptr),
+                                shift = in(reg_nonzero) shift,
+                                mask = inout(reg_nonzero) mask => _,
+                                tmp1 = out(reg_nonzero) _,
+                                tmp2 = out(reg_nonzero) _,
+                                out("cr0") _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: Cr;
+                    // Implement sub-word atomic operations using word-sized LL/SC loop.
+                    // Based on assemblies generated by rustc/LLVM.
+                    // See also partword.rs.
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                concat!("l", $l_suffix, " {old}, 0({old})"),
+                                concat!("l", $l_suffix, " {new}, 0({new})"),
+                                "slw {mask}, {mask}, {shift}",
+                                "slw {old}, {old}, {shift}",
+                                "slw {new}, {new}, {shift}",
+                                "and {old}, {old}, {mask}",
+                                "and {new}, {new}, {mask}",
+                                // (atomic) CAS (LL/SC loop)
+                                $release,
+                                "2:",
+                                    "lwarx {tmp2}, 0, {dst}",
+                                    "and {tmp1}, {tmp2}, {mask}",
+                                    "cmpw {tmp1}, {old}",
+                                    "bne %cr0, 3f",
+                                    "andc {tmp2}, {tmp2}, {mask}",
+                                    "or {tmp2}, {tmp2}, {new}",
+                                    "stwcx. {tmp2}, 0, {dst}",
+                                    "bne %cr0, 2b",
+                                "3:",
+                                "srw {tmp1}, {tmp1}, {shift}",
+                                // if compare failed EQ bit is cleared, if stqcx succeeds EQ bit is set.
+                                "mfcr {r}",
+                                $acquire,
+                                concat!("st", $asm_suffix, " {tmp1}, 0({out})"),
+                                dst = in(reg_nonzero) ptr_reg!(aligned_ptr),
+                                old = inout(reg_nonzero) ptr_reg!(old) => _,
+                                new = inout(reg_nonzero) ptr_reg!(new) => _,
+                                out = inout(reg_nonzero) ptr_reg!(out_ptr) => _,
+                                shift = in(reg_nonzero) shift,
+                                mask = inout(reg_nonzero) mask => _,
+                                r = lateout(reg_nonzero) r,
+                                tmp1 = out(reg_nonzero) _,
+                                tmp2 = out(reg_nonzero) _,
+                                out("cr0") _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg, order);
+                    (out, extract_cr0(r))
+                }
+            }
+        }
+    };
+}
+
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "partword-atomics",
+    atomic_maybe_uninit_target_feature = "partword-atomics",
+))]
+atomic!(i8, "bz", "b", "w");
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "partword-atomics",
+    atomic_maybe_uninit_target_feature = "partword-atomics",
+))]
+atomic!(u8, "bz", "b", "w");
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "partword-atomics",
+    atomic_maybe_uninit_target_feature = "partword-atomics",
+))]
+atomic!(i16, "hz", "h", "w");
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "partword-atomics",
+    atomic_maybe_uninit_target_feature = "partword-atomics",
+))]
+atomic!(u16, "hz", "h", "w");
+#[cfg(not(all(
+    target_arch = "powerpc64",
+    any(
+        target_feature = "partword-atomics",
+        atomic_maybe_uninit_target_feature = "partword-atomics",
+    ),
+)))]
+atomic_sub_word!(i8, "bz", "b");
+#[cfg(not(all(
+    target_arch = "powerpc64",
+    any(
+        target_feature = "partword-atomics",
+        atomic_maybe_uninit_target_feature = "partword-atomics",
+    ),
+)))]
+atomic_sub_word!(u8, "bz", "b");
+#[cfg(not(all(
+    target_arch = "powerpc64",
+    any(
+        target_feature = "partword-atomics",
+        atomic_maybe_uninit_target_feature = "partword-atomics",
+    ),
+)))]
+atomic_sub_word!(i16, "hz", "h");
+#[cfg(not(all(
+    target_arch = "powerpc64",
+    any(
+        target_feature = "partword-atomics",
+        atomic_maybe_uninit_target_feature = "partword-atomics",
+    ),
+)))]
+atomic_sub_word!(u16, "hz", "h");
+atomic!(i32, "wz", "w", "w");
+atomic!(u32, "wz", "w", "w");
+#[cfg(target_arch = "powerpc64")]
+atomic!(i64, "d", "d", "d");
+#[cfg(target_arch = "powerpc64")]
+atomic!(u64, "d", "d", "d");
+#[cfg(target_pointer_width = "32")]
+atomic!(isize, "wz", "w", "w");
+#[cfg(target_pointer_width = "32")]
+atomic!(usize, "wz", "w", "w");
+#[cfg(target_pointer_width = "64")]
+atomic!(isize, "d", "d", "d");
+#[cfg(target_pointer_width = "64")]
+atomic!(usize, "d", "d", "d");
+
+// https://github.com/llvm/llvm-project/commit/549e118e93c666914a1045fde38a2cac33e1e445
+// https://github.com/llvm/llvm-project/blob/llvmorg-17.0.0-rc2/llvm/test/CodeGen/PowerPC/atomics-i128-ldst.ll
+// https://github.com/llvm/llvm-project/blob/llvmorg-17.0.0-rc2/llvm/test/CodeGen/PowerPC/atomics-i128.ll
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "quadword-atomics",
+    atomic_maybe_uninit_target_feature = "quadword-atomics",
+))]
+macro_rules! atomic128 {
+    ($int_type:ident) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load_acquire {
+                        ($release:tt) => {
+                            asm!(
+                                // (atomic) load from src to out pair
+                                $release,
+                                "lq %r4, 0({src})",
+                                // Refs: https://github.com/boostorg/atomic/blob/boost-1.79.0/include/boost/atomic/detail/core_arch_ops_gcc_ppc.hpp#L47-L62
+                                "cmpd %cr7, %r4, %r4",
+                                "bne- %cr7, 2f",
+                                "2:",
+                                "isync",
+                                // store out pair to out
+                                concat!("std %r4, ", p128h!(), "({out})"),
+                                concat!("std %r5, ", p128l!(), "({out})"),
+                                src = in(reg_nonzero) ptr_reg!(src),
+                                out = inout(reg_nonzero) ptr_reg!(out_ptr) => _,
+                                // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
+                                // We cannot use r1 (sp) and r2 (system reserved), so start with r4 or grater.
+                                out("r4") _, // out (hi)
+                                out("r5") _, // out (lo)
+                                out("cr7") _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => {
+                            asm!(
+                                // (atomic) load from src to out pair
+                                "lq %r4, 0({src})",
+                                // store out pair to out
+                                concat!("std %r4, ", p128h!(), "({out})"),
+                                concat!("std %r5, ", p128l!(), "({out})"),
+                                src = in(reg_nonzero) ptr_reg!(src),
+                                out = inout(reg_nonzero) ptr_reg!(out_ptr) => _,
+                                // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
+                                // We cannot use r1 (sp) and r2 (system reserved), so start with r4 or grater.
+                                out("r4") _, // out (hi)
+                                out("r5") _, // out (lo)
+                                options(nostack, preserves_flags),
+                            )
+                        }
+                        Ordering::Acquire => atomic_load_acquire!(""),
+                        Ordering::SeqCst => atomic_load_acquire!("sync"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($release:tt) => {
+                            asm!(
+                                // load from val to val pair
+                                concat!("ld %r4, ", p128h!(), "({val})"),
+                                concat!("ld %r5, ", p128l!(), "({val})"),
+                                // (atomic) store val pair to dst
+                                $release,
+                                "stq %r4, 0({dst})",
+                                dst = inout(reg_nonzero) ptr_reg!(dst) => _,
+                                val = in(reg_nonzero) ptr_reg!(val),
+                                // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
+                                // We cannot use r1 (sp) and r2 (system reserved), so start with r4 or grater.
+                                out("r4") _, // val (hi)
+                                lateout("r5") _, // val (lo)
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_store!(""),
+                        Ordering::Release => atomic_store!("lwsync"),
+                        Ordering::SeqCst => atomic_store!("sync"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from val to val pair
+                                concat!("ld %r4, ", p128h!(), "({val})"),
+                                concat!("ld %r5, ", p128l!(), "({val})"),
+                                // (atomic) swap (LL/SC loop)
+                                $release,
+                                "2:",
+                                    // load from dst to out pair
+                                    "lqarx %r6, 0, {dst}",
+                                    // try to store val pair to dst
+                                    "stqcx. %r4, 0, {dst}",
+                                    "bne %cr0, 2b",
+                                $acquire,
+                                // store out pair to out
+                                concat!("std %r6, ", p128h!(), "({out})"),
+                                concat!("std %r7, ", p128l!(), "({out})"),
+                                dst = inout(reg_nonzero) ptr_reg!(dst) => _,
+                                val = in(reg_nonzero) ptr_reg!(val),
+                                out = inout(reg_nonzero) ptr_reg!(out_ptr) => _,
+                                // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
+                                // We cannot use r1 (sp) and r2 (system reserved), so start with r4 or grater.
+                                out("r4") _, // val (hi)
+                                lateout("r5") _, // val (lo)
+                                out("r6") _, // out (hi)
+                                out("r7") _, // out (lo)
+                                out("cr0") _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: Cr;
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from old/new to old/new pairs
+                                concat!("ld %r4, ", p128h!(), "({old})"),
+                                concat!("ld %r5, ", p128l!(), "({old})"),
+                                concat!("ld %r6, ", p128h!(), "({new})"),
+                                concat!("ld %r7, ", p128l!(), "({new})"),
+                                // (atomic) CAS (LL/SC loop)
+                                $release,
+                                "2:",
+                                    "lqarx %r8, 0, {dst}",
+                                    "xor {tmp_lo}, %r9, %r5",
+                                    "xor {tmp_hi}, %r8, %r4",
+                                    "or. {tmp_lo}, {tmp_lo}, {tmp_hi}",
+                                    "bne %cr0, 3f", // jump if compare failed
+                                    "stqcx. %r6, 0, {dst}",
+                                    "bne %cr0, 2b", // continue loop if store failed
+                                "3:",
+                                // if compare failed EQ bit is cleared, if stqcx succeeds EQ bit is set.
+                                "mfcr {tmp_lo}",
+                                $acquire,
+                                // store out pair to out
+                                concat!("std %r8, ", p128h!(), "({out})"),
+                                concat!("std %r9, ", p128l!(), "({out})"),
+                                dst = inout(reg_nonzero) ptr_reg!(dst) => _,
+                                old = in(reg_nonzero) ptr_reg!(old),
+                                new = in(reg_nonzero) ptr_reg!(new),
+                                out = inout(reg_nonzero) ptr_reg!(out_ptr) => _,
+                                tmp_hi = out(reg_nonzero) _,
+                                tmp_lo = out(reg_nonzero) r,
+                                // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
+                                // We cannot use r1 (sp) and r2 (system reserved), so start with r4 or grater.
+                                out("r4") _, // old (hi)
+                                out("r5") _, // old (lo)
+                                out("r6") _, // new (hi)
+                                lateout("r7") _, // new (lo)
+                                lateout("r8") _, // out (hi)
+                                lateout("r9") _, // out (lo)
+                                out("cr0") _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg, order);
+                    (out, extract_cr0(r))
+                }
+            }
+        }
+    };
+}
+
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "quadword-atomics",
+    atomic_maybe_uninit_target_feature = "quadword-atomics",
+))]
+atomic128!(i128);
+#[cfg(target_arch = "powerpc64")]
+#[cfg(any(
+    target_feature = "quadword-atomics",
+    atomic_maybe_uninit_target_feature = "quadword-atomics",
+))]
+atomic128!(u128);
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(target_arch = "powerpc")]
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(target_arch = "powerpc")]
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(target_arch = "powerpc64")]
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(target_arch = "powerpc64")]
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(not(all(
+    target_arch = "powerpc64",
+    any(
+        target_feature = "quadword-atomics",
+        atomic_maybe_uninit_target_feature = "quadword-atomics",
+    ),
+)))]
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(not(all(
+    target_arch = "powerpc64",
+    any(
+        target_feature = "quadword-atomics",
+        atomic_maybe_uninit_target_feature = "quadword-atomics",
+    ),
+)))]
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(all(
+    target_arch = "powerpc64",
+    any(
+        target_feature = "quadword-atomics",
+        atomic_maybe_uninit_target_feature = "quadword-atomics",
+    ),
+))]
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(all(
+    target_arch = "powerpc64",
+    any(
+        target_feature = "quadword-atomics",
+        atomic_maybe_uninit_target_feature = "quadword-atomics",
+    ),
+))]
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}

--- a/src/arch_legacy/riscv.rs
+++ b/src/arch_legacy/riscv.rs
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// RISC-V
+//
+// Refs:
+// - RISC-V Atomics ABI Specification
+//   https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/HEAD/riscv-atomic.adoc
+// - "Mappings from C/C++ primitives to RISC-V primitives." table in RISC-V Instruction Set Manual:
+//   https://five-embeddev.com/riscv-isa-manual/latest/memory.html#sec:memory:porting
+// - RISC-V Instruction Set Specifications https://msyksphinz-self.github.io/riscv-isadoc/html/index.html
+// - portable-atomic https://github.com/taiki-e/portable-atomic
+//
+// Generated asm:
+// - riscv64gc https://godbolt.org/z/nW3Po8n4K
+// - riscv32imac https://godbolt.org/z/51nPPMYze
+
+#[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+#[path = "../arch/partword.rs"]
+mod partword;
+
+use core::{
+    arch::asm,
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+#[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+use crate::raw::{AtomicCompareExchange, AtomicSwap};
+use crate::raw::{AtomicLoad, AtomicStore};
+
+#[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+#[cfg(target_arch = "riscv32")]
+macro_rules! w {
+    () => {
+        ""
+    };
+}
+#[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+#[cfg(target_arch = "riscv64")]
+macro_rules! w {
+    () => {
+        "w"
+    };
+}
+
+#[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+macro_rules! atomic_rmw_amo {
+    ($op:ident, $order:ident) => {
+        match $order {
+            Ordering::Relaxed => $op!(""),
+            Ordering::Acquire => $op!(".aq"),
+            Ordering::Release => $op!(".rl"),
+            // AcqRel and SeqCst RMWs are equivalent.
+            Ordering::AcqRel | Ordering::SeqCst => $op!(".aqrl"),
+            _ => unreachable!("{:?}", $order),
+        }
+    };
+}
+#[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+macro_rules! atomic_rmw_lr_sc {
+    ($op:ident, $order:ident) => {
+        match $order {
+            Ordering::Relaxed => $op!("", ""),
+            Ordering::Acquire => $op!(".aq", ""),
+            Ordering::Release => $op!("", ".rl"),
+            Ordering::AcqRel => $op!(".aq", ".rl"),
+            Ordering::SeqCst => $op!(".aqrl", ".rl"),
+            _ => unreachable!("{:?}", $order),
+        }
+    };
+}
+
+#[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+#[cfg(target_arch = "riscv32")]
+type XSize = u32;
+#[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+#[cfg(target_arch = "riscv64")]
+type XSize = u64;
+
+#[rustfmt::skip]
+macro_rules! atomic_load_store {
+    ($int_type:ident, $asm_suffix:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // (atomic) load from src to tmp
+                                $release,
+                                concat!("l", $asm_suffix, " {tmp}, 0({src})"),
+                                $acquire,
+                                // store tmp to out
+                                concat!("s", $asm_suffix, " {tmp}, 0({out})"),
+                                src = in(reg) ptr_reg!(src),
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!("", ""),
+                        Ordering::Acquire => atomic_load!("fence r, rw", ""),
+                        Ordering::SeqCst => atomic_load!("fence r, rw", "fence rw, rw"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($release:tt) => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("l", $asm_suffix, " {tmp}, 0({val})"),
+                                // (atomic) store tmp to dst
+                                $release,
+                                concat!("s", $asm_suffix, " {tmp}, 0({dst})"),
+                                dst = inout(reg) ptr_reg!(dst) => _,
+                                val = in(reg) ptr_reg!(val),
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_store!(""),
+                        // Release and SeqCst stores are equivalent.
+                        Ordering::Release | Ordering::SeqCst => atomic_store!("fence rw, w"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! atomic {
+    ($int_type:ident, $asm_suffix:tt) => {
+        atomic_load_store!($int_type, $asm_suffix);
+        #[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! swap {
+                        ($order:tt) => {
+                            asm!(
+                                // load from val (ptr) to val (val)
+                                concat!("l", $asm_suffix, " {val}, 0({val})"),
+                                // (atomic) swap (AMO)
+                                // - load value from dst and store it to tmp
+                                // - store value of val to dst
+                                concat!("amoswap.", $asm_suffix, $order, " {tmp}, {val}, 0({dst})"),
+                                // store tmp to out
+                                concat!("s", $asm_suffix, " {tmp}, 0({out})"),
+                                dst = in(reg) ptr_reg!(dst),
+                                val = inout(reg) ptr_reg!(val) => _,
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                tmp = lateout(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw_amo!(swap, order);
+                }
+                out
+            }
+        }
+        #[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: XSize;
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                // load from old/new (ptr) to old/new (val)
+                                concat!("l", $asm_suffix, " {old}, 0({old})"),
+                                concat!("l", $asm_suffix, " {new}, 0({new})"),
+                                // (atomic) CAS (LR/SC loop)
+                                "2:",
+                                    concat!("lr.", $asm_suffix, $acquire, " {tmp}, 0({dst})"),
+                                    "bne {tmp}, {old}, 3f", // compare and jump if compare failed
+                                    concat!("sc.", $asm_suffix, $release, " {r}, {new}, 0({dst})"),
+                                    "bnez {r}, 2b", // continue loop if store failed
+                                "3:",
+                                "xor {r}, {tmp}, {old}",
+                                "seqz {r}, {r}",
+                                // store tmp to out
+                                concat!("s", $asm_suffix, " {tmp}, 0({out})"),
+                                dst = in(reg) ptr_reg!(dst),
+                                old = inout(reg) ptr_reg!(old) => _,
+                                new = inout(reg) ptr_reg!(new) => _,
+                                out = in(reg) ptr_reg!(out_ptr),
+                                tmp = out(reg) _,
+                                r = out(reg) r,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw_lr_sc!(cmpxchg, order);
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! atomic_sub_word {
+    ($int_type:ident, $asm_suffix:tt) => {
+        atomic_load_store!($int_type, $asm_suffix);
+        #[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // Implement sub-word atomic operations using word-sized LL/SC loop.
+                    // Based on assemblies generated by rustc/LLVM.
+                    // See also partword.rs.
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                concat!("l", $asm_suffix, "u {val}, 0({val})"),
+                                concat!("sll", w!(), " {mask}, {mask}, {shift}"),
+                                concat!("sll", w!(), " {val}, {val}, {shift}"),
+                                // (atomic) swap (LR/SC loop)
+                                "2:",
+                                    concat!("lr.w", $acquire, " {tmp1}, 0({dst})"),
+                                    "mv {tmp2}, {val}",
+                                    "xor {tmp2}, {tmp2}, {tmp1}",
+                                    "and {tmp2}, {tmp2}, {mask}",
+                                    "xor {tmp2}, {tmp2}, {tmp1}",
+                                    concat!("sc.w", $release, " {tmp2}, {tmp2}, 0({dst})"),
+                                    "bnez {tmp2}, 2b",
+                                concat!("srl", w!(), " {tmp1}, {tmp1}, {shift}"),
+                                concat!("s", $asm_suffix, " {tmp1}, 0({out})"),
+                                dst = in(reg) ptr_reg!(aligned_ptr),
+                                val = inout(reg) ptr_reg!(val) => _,
+                                out = in(reg) ptr_reg!(out_ptr),
+                                shift = in(reg) shift,
+                                mask = inout(reg) mask => _,
+                                tmp1 = out(reg) _,
+                                tmp2 = out(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw_lr_sc!(swap, order);
+                }
+                out
+            }
+        }
+        #[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let (aligned_ptr, shift, mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: XSize;
+                    // Implement sub-word atomic operations using word-sized LL/SC loop.
+                    // Based on assemblies generated by rustc/LLVM.
+                    // See also partword.rs.
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                concat!("l", $asm_suffix, "u {old}, 0({old})"),
+                                concat!("l", $asm_suffix, "u {new}, 0({new})"),
+                                concat!("sll", w!(), " {mask}, {mask}, {shift}"),
+                                concat!("sll", w!(), " {old}, {old}, {shift}"),
+                                concat!("sll", w!(), " {new}, {new}, {shift}"),
+                                // (atomic) CAS (LR/SC loop)
+                                "2:",
+                                    concat!("lr.w", $acquire, " {tmp1}, 0({dst})"),
+                                    "and {tmp2}, {tmp1}, {mask}",
+                                    "bne {tmp2}, {old}, 3f",
+                                    "xor {tmp2}, {tmp1}, {new}",
+                                    "and {tmp2}, {tmp2}, {mask}",
+                                    "xor {tmp2}, {tmp2}, {tmp1}",
+                                    concat!("sc.w", $release, " {tmp2}, {tmp2}, 0({dst})"),
+                                    "bnez {tmp2}, 2b",
+                                "3:",
+                                concat!("srl", w!(), " {tmp2}, {tmp1}, {shift}"),
+                                "and {tmp1}, {tmp1}, {mask}",
+                                "xor {r}, {old}, {tmp1}",
+                                "seqz {r}, {r}",
+                                concat!("s", $asm_suffix, " {tmp2}, 0({out})"),
+                                dst = in(reg) ptr_reg!(aligned_ptr),
+                                old = inout(reg) ptr_reg!(old) => _,
+                                new = inout(reg) ptr_reg!(new) => _,
+                                out = inout(reg) ptr_reg!(out_ptr) => _,
+                                shift = in(reg) shift,
+                                mask = inout(reg) mask => _,
+                                r = lateout(reg) r,
+                                tmp1 = out(reg) _,
+                                tmp2 = out(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw_lr_sc!(cmpxchg, order);
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+atomic_sub_word!(i8, "b");
+atomic_sub_word!(u8, "b");
+atomic_sub_word!(i16, "h");
+atomic_sub_word!(u16, "h");
+atomic!(i32, "w");
+atomic!(u32, "w");
+#[cfg(target_arch = "riscv64")]
+atomic!(i64, "d");
+#[cfg(target_arch = "riscv64")]
+atomic!(u64, "d");
+#[cfg(target_pointer_width = "32")]
+atomic!(isize, "w");
+#[cfg(target_pointer_width = "32")]
+atomic!(usize, "w");
+#[cfg(target_pointer_width = "64")]
+atomic!(isize, "d");
+#[cfg(target_pointer_width = "64")]
+atomic!(usize, "d");
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(target_arch = "riscv32")]
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(target_arch = "riscv32")]
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(target_arch = "riscv64")]
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(target_arch = "riscv64")]
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a"))]
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}
+#[cfg(not(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a")))]
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => {};
+}
+#[cfg(not(any(target_feature = "a", atomic_maybe_uninit_target_feature = "a")))]
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}

--- a/src/arch_legacy/s390x.rs
+++ b/src/arch_legacy/s390x.rs
@@ -1,0 +1,544 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// s390x
+//
+// Refs:
+// - z/Architecture Principles of Operation https://publibfp.dhe.ibm.com/epubs/pdf/a227832d.pdf
+// - z/Architecture Reference Summary https://www.ibm.com/support/pages/zarchitecture-reference-summary
+// - portable-atomic https://github.com/taiki-e/portable-atomic
+//
+// Generated asm:
+// - s390x https://godbolt.org/z/qv8s6o13G
+// - s390x (z196) https://godbolt.org/z/jW67E4YEq
+
+#[path = "../arch/partword.rs"]
+mod partword;
+
+use core::{
+    arch::asm,
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+use crate::raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap};
+
+type XSize = u64;
+
+// Extracts and checks condition code.
+#[inline]
+fn extract_cc(r: i64) -> bool {
+    let r = r.wrapping_add(-268435456) & (1 << 31);
+    debug_assert!(r == 0 || r == 2147483648, "r={r}");
+    r != 0
+}
+
+#[inline]
+fn complement(v: u32) -> u32 {
+    (v ^ !0).wrapping_add(1)
+}
+
+macro_rules! atomic_load_store {
+    ($int_type:ident, $l_suffix:tt, $asm_suffix:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // atomic load is always SeqCst.
+                    asm!(
+                        // (atomic) load from src to r0
+                        concat!("l", $l_suffix, " %r0, 0({src})"),
+                        // store r0 to out
+                        concat!("st", $asm_suffix, " %r0, 0({out})"),
+                        src = in(reg) ptr_reg!(src),
+                        out = in(reg) ptr_reg!(out_ptr),
+                        out("r0") _,
+                        options(nostack, preserves_flags),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($fence:tt) => {
+                            asm!(
+                                // load from val to r0
+                                concat!("l", $l_suffix, " %r0, 0({val})"),
+                                // (atomic) store r0 to dst
+                                concat!("st", $asm_suffix, " %r0, 0({dst})"),
+                                $fence,
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(reg) ptr_reg!(val),
+                                out("r0") _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        // Relaxed and Release stores are equivalent.
+                        Ordering::Relaxed | Ordering::Release => atomic_store!(""),
+                        // bcr 14,0 (fast-BCR-serialization) requires z196 or later.
+                        #[cfg(any(
+                            target_feature = "fast-serialization",
+                            atomic_maybe_uninit_target_feature = "fast-serialization",
+                        ))]
+                        Ordering::SeqCst => atomic_store!("bcr 14, 0"),
+                        #[cfg(not(any(
+                            target_feature = "fast-serialization",
+                            atomic_maybe_uninit_target_feature = "fast-serialization",
+                        )))]
+                        Ordering::SeqCst => atomic_store!("bcr 15, 0"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! atomic {
+    ($int_type:ident, $asm_suffix:tt) => {
+        atomic_load_store!($int_type, $asm_suffix, $asm_suffix);
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // atomic swap is always SeqCst.
+                    asm!(
+                        // load from val to val_tmp
+                        concat!("l", $asm_suffix, " {val_tmp}, 0({val})"),
+                        // (atomic) swap (CAS loop)
+                        concat!("l", $asm_suffix, " %r0, 0({dst})"),
+                        "2:",
+                            concat!("cs", $asm_suffix, " %r0, {val_tmp}, 0({dst})"),
+                            "jl 2b",
+                        // store r0 to out
+                        concat!("st", $asm_suffix, " %r0, 0({out})"),
+                        dst = in(reg) ptr_reg!(dst),
+                        val = in(reg) ptr_reg!(val),
+                        val_tmp = out(reg) _,
+                        out = in(reg) ptr_reg!(out_ptr),
+                        out("r0") _,
+                        // Do not use `preserves_flags` because CS modifies the condition code.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i64;
+                    // compare_exchange is always SeqCst.
+                    asm!(
+                        // load from old/new to r0/tmp
+                        concat!("l", $asm_suffix, " %r0, 0({old})"),
+                        concat!("l", $asm_suffix, " {tmp}, 0({new})"),
+                        // (atomic) CAS
+                        concat!("cs", $asm_suffix, " %r0, {tmp}, 0({dst})"),
+                        // store condition code
+                        "ipm {tmp}",
+                        // store r0 to out
+                        concat!("st", $asm_suffix, " %r0, 0({out})"),
+                        dst = in(reg) ptr_reg!(dst),
+                        old = in(reg) ptr_reg!(old),
+                        new = in(reg) ptr_reg!(new),
+                        tmp = out(reg) r,
+                        out = in(reg) ptr_reg!(out_ptr),
+                        out("r0") _,
+                        // Do not use `preserves_flags` because CS modifies the condition code.
+                        options(nostack),
+                    );
+                    (out, extract_cc(r))
+                }
+            }
+        }
+    };
+}
+
+macro_rules! atomic_sub_word {
+    ($int_type:ident, $l_suffix:tt, $asm_suffix:tt, $bits:tt, $risbg_swap:tt, $risbg_cas:tt) => {
+        atomic_load_store!($int_type, $l_suffix, $asm_suffix);
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let (aligned_ptr, shift, _mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // Implement sub-word atomic operations using word-sized CAS loop.
+                    // Based on assemblies generated by rustc/LLVM.
+                    // See also partword.rs.
+                    asm!(
+                        concat!("l", $l_suffix, " %r0, 0(%r3)"),
+                        "l %r3, 0({dst})",
+                        "2:",
+                            "rll %r14, %r3, 0({shift})",
+                            concat!("risbg %r14, %r0, 32, ", $risbg_swap),
+                            "rll %r14, %r14, 0({shift_c})",
+                            "cs %r3, %r14, 0({dst})",
+                            "jl 2b",
+                        concat!("rll %r0, %r3, ", $bits ,"({shift})"),
+                        concat!("st", $asm_suffix, " %r0, 0({out})"),
+                        dst = in(reg) ptr_reg!(aligned_ptr),
+                        out = in(reg) ptr_reg!(out_ptr),
+                        shift = in(reg) shift as u32,
+                        shift_c = in(reg) complement(shift as u32),
+                        out("r0") _,
+                        inout("r3") ptr_reg!(val) => _,
+                        out("r14") _,
+                        // Do not use `preserves_flags` because CS modifies the condition code.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let (aligned_ptr, shift, _mask) = partword::create_mask_values(dst);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i64;
+                    // Implement sub-word atomic operations using word-sized CAS loop.
+                    // Based on assemblies generated by rustc/LLVM.
+                    // See also partword.rs.
+                    asm!(
+                        concat!("ll", $asm_suffix, " %r0, 0(%r3)"),
+                        concat!("l", $l_suffix, " %r1, 0(%r4)"),
+                        "l %r4, 0({dst})",
+                        "2:",
+                            concat!("rll %r13, %r4, ", $bits ,"({shift})"),
+                            concat!("risbg %r1, %r13, 32, ", $risbg_cas, ", 0"),
+                            concat!("ll", $asm_suffix, "r %r13, %r13"),
+                            "cr %r13, %r0",
+                            "jlh 3f",
+                            concat!("rll %r3, %r1, -", $bits ,"({shift_c})"),
+                            "cs %r4, %r3, 0({dst})",
+                            "jl 2b",
+                        "3:",
+                        // store condition code
+                        "ipm %r0",
+                        concat!("st", $asm_suffix, " %r13, 0({out})"),
+                        dst = in(reg) ptr_reg!(aligned_ptr),
+                        out = in(reg) ptr_reg!(out_ptr),
+                        shift = in(reg) shift as u32,
+                        shift_c = in(reg) complement(shift as u32),
+                        out("r0") r,
+                        out("r1") _,
+                        inout("r3") ptr_reg!(old) => _,
+                        inout("r4") ptr_reg!(new) => _,
+                        out("r13") _,
+                        // Do not use `preserves_flags` because CS modifies the condition code.
+                        options(nostack),
+                    );
+                    (out, extract_cc(r))
+                }
+            }
+        }
+    };
+}
+
+atomic_sub_word!(i8, "b", "c", "8", "39, 24", "55");
+atomic_sub_word!(u8, "b", "c", "8", "39, 24", "55");
+atomic_sub_word!(i16, "h", "h", "16", "47, 16", "47");
+atomic_sub_word!(u16, "h", "h", "16", "47, 16", "47");
+atomic!(i32, "");
+atomic!(u32, "");
+atomic!(i64, "g");
+atomic!(u64, "g");
+atomic!(isize, "g");
+atomic!(usize, "g");
+
+// https://github.com/llvm/llvm-project/commit/a11f63a952664f700f076fd754476a2b9eb158cc
+macro_rules! atomic128 {
+    ($int_type:ident) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // atomic load is always SeqCst.
+                    asm!(
+                        // (atomic) load from src to out pair
+                        "lpq %r0, 0({src})",
+                        // store out pair to out
+                        "stg %r1, 8({out})",
+                        "stg %r0, 0({out})",
+                        src = in(reg) ptr_reg!(src),
+                        out = in(reg) ptr_reg!(out_ptr),
+                        // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
+                        out("r0") _, // out (hi)
+                        out("r1") _, // out (lo)
+                        options(nostack, preserves_flags),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_store {
+                        ($fence:tt) => {
+                            asm!(
+                                // load from val to val pair
+                                "lg %r1, 8({val})",
+                                "lg %r0, 0({val})",
+                                // (atomic) store val pair to dst
+                                "stpq %r0, 0({dst})",
+                                $fence,
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(reg) ptr_reg!(val),
+                                // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
+                                out("r0") _, // val (hi)
+                                out("r1") _, // val (lo)
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        // Relaxed and Release stores are equivalent.
+                        Ordering::Relaxed | Ordering::Release => atomic_store!(""),
+                        // bcr 14,0 (fast-BCR-serialization) requires z196 or later.
+                        #[cfg(any(
+                            target_feature = "fast-serialization",
+                            atomic_maybe_uninit_target_feature = "fast-serialization",
+                        ))]
+                        Ordering::SeqCst => atomic_store!("bcr 14, 0"),
+                        #[cfg(not(any(
+                            target_feature = "fast-serialization",
+                            atomic_maybe_uninit_target_feature = "fast-serialization",
+                        )))]
+                        Ordering::SeqCst => atomic_store!("bcr 15, 0"),
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // atomic swap is always SeqCst.
+                    asm!(
+                        // load from val to val pair
+                        "lg %r1, 8({val})",
+                        "lg %r0, 0({val})",
+                        // (atomic) swap (CAS loop)
+                        "lpq %r2, 0({dst})",
+                        "2:",
+                            "cdsg %r2, %r0, 0({dst})",
+                            "jl 2b",
+                        // store out pair to out
+                        "stg %r3, 8({out})",
+                        "stg %r2, 0({out})",
+                        dst = inout(reg) ptr_reg!(dst) => _,
+                        val = in(reg) ptr_reg!(val),
+                        out = inout(reg) ptr_reg!(out_ptr) => _,
+                        // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
+                        out("r0") _, // val (hi)
+                        out("r1") _, // val (lo)
+                        lateout("r2") _, // out (hi)
+                        lateout("r3") _, // out (lo)
+                        // Do not use `preserves_flags` because CDSG modifies the condition code.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: i64;
+                    // compare_exchange is always SeqCst.
+                    asm!(
+                        // load from old/new to old/new pairs
+                        "lg %r1, 8({old})",
+                        "lg %r0, 0({old})",
+                        "lg %r13, 8({new})",
+                        "lg %r12, 0({new})",
+                        // (atomic) CAS
+                        "cdsg %r0, %r12, 0({dst})",
+                        // store condition code
+                        "ipm {r}",
+                        // store out pair to out
+                        "stg %r1, 8({out})",
+                        "stg %r0, 0({out})",
+                        dst = in(reg) ptr_reg!(dst),
+                        old = in(reg) ptr_reg!(old),
+                        new = in(reg) ptr_reg!(new),
+                        out = inout(reg) ptr_reg!(out_ptr) => _,
+                        r = lateout(reg) r,
+                        // Quadword atomic instructions work with even/odd pair of specified register and subsequent register.
+                        out("r0") _, // old (hi) -> out (hi)
+                        out("r1") _, // old (lo) -> out (lo)
+                        out("r12") _, // new (hi)
+                        out("r13") _, // new (hi)
+                        // Do not use `preserves_flags` because CDSG modifies the condition code.
+                        options(nostack),
+                    );
+                    (out, extract_cc(r))
+                }
+            }
+        }
+    };
+}
+
+atomic128!(i128);
+atomic128!(u128);
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}

--- a/src/arch_legacy/x86.rs
+++ b/src/arch_legacy/x86.rs
@@ -1,0 +1,840 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// x86 and x86_64
+//
+// Refs:
+// - x86 and amd64 instruction reference https://www.felixcloutier.com/x86
+// - portable-atomic https://github.com/taiki-e/portable-atomic
+//
+// Generated asm:
+// - x86_64 https://godbolt.org/z/fvqWGT5E6
+// - x86_64 (+cmpxchg16b) https://godbolt.org/z/fGdj8naT9
+// - x86 (i686) https://godbolt.org/z/9jKcboaoG
+// - x86 (i686,-sse2) https://godbolt.org/z/sjYK57r96
+// - x86 (i586) https://godbolt.org/z/5rrzYGxPe
+// - x86 (i586,-x87) https://godbolt.org/z/GvcdhqxYo
+// - x86 (i486) https://godbolt.org/z/nPaGY4oEM
+// - x86 (i386) https://godbolt.org/z/YWEc63Kac
+
+use core::{
+    arch::asm,
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+use crate::raw::{AtomicCompareExchange, AtomicLoad, AtomicStore, AtomicSwap};
+
+#[cfg(target_pointer_width = "32")]
+macro_rules! ptr_modifier {
+    () => {
+        ":e"
+    };
+}
+#[cfg(target_pointer_width = "64")]
+macro_rules! ptr_modifier {
+    () => {
+        ""
+    };
+}
+
+#[cfg(target_arch = "x86")]
+#[cfg(not(atomic_maybe_uninit_no_cmpxchg8b))]
+#[cfg(target_feature = "sse")]
+#[cfg(target_feature = "sse2")]
+macro_rules! if_sse2 {
+    ($then:expr, $else:expr) => {
+        $then
+    };
+}
+#[cfg(target_arch = "x86")]
+#[cfg(not(atomic_maybe_uninit_no_cmpxchg8b))]
+#[cfg(target_feature = "sse")]
+#[cfg(not(target_feature = "sse2"))]
+macro_rules! if_sse2 {
+    ($then:expr, $else:expr) => {
+        $else
+    };
+}
+
+macro_rules! atomic {
+    ($int_type:ident, $val_reg:tt, $val_modifier:tt, $ptr_size:tt, $cmpxchg_cmp_reg:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // atomic load is always SeqCst.
+                    asm!(
+                        // (atomic) load from src to tmp
+                        concat!("mov {tmp", $val_modifier, "}, ", $ptr_size, " ptr [{src", ptr_modifier!(), "}]"),
+                        // store tmp to out
+                        concat!("mov ", $ptr_size, " ptr [{out", ptr_modifier!(), "}], {tmp", $val_modifier, "}"),
+                        src = in(reg) src,
+                        out = inout(reg) out_ptr => _,
+                        tmp = lateout($val_reg) _,
+                        options(nostack, preserves_flags),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    match order {
+                        // Relaxed and Release stores are equivalent.
+                        Ordering::Relaxed | Ordering::Release => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("mov {tmp", $val_modifier, "}, ", $ptr_size, " ptr [{val", ptr_modifier!(), "}]"),
+                                // (atomic) store tmp to dst
+                                concat!("mov ", $ptr_size, " ptr [{dst", ptr_modifier!(), "}], {tmp", $val_modifier, "}"),
+                                dst = inout(reg) dst => _,
+                                val = in(reg) val,
+                                tmp = lateout($val_reg) _,
+                                options(nostack, preserves_flags),
+                            );
+                        }
+                        Ordering::SeqCst => {
+                            asm!(
+                                // load from val to tmp
+                                concat!("mov {tmp", $val_modifier, "}, ", $ptr_size, " ptr [{val", ptr_modifier!(), "}]"),
+                                // (atomic) store tmp to dst (SeqCst store is xchg, not mov)
+                                concat!("xchg ", $ptr_size, " ptr [{dst", ptr_modifier!(), "}], {tmp", $val_modifier, "}"),
+                                dst = inout(reg) dst => _,
+                                val = in(reg) val,
+                                tmp = lateout($val_reg) _,
+                                options(nostack, preserves_flags),
+                            );
+                        }
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    // atomic swap is always SeqCst.
+                    asm!(
+                        // load from val to tmp
+                        concat!("mov {tmp", $val_modifier, "}, ", $ptr_size, " ptr [{val", ptr_modifier!(), "}]"),
+                        // (atomic) swap tmp and dst
+                        concat!("xchg ", $ptr_size, " ptr [{dst", ptr_modifier!(), "}], {tmp", $val_modifier, "}"),
+                        // store tmp to out
+                        concat!("mov ", $ptr_size, " ptr [{out", ptr_modifier!(), "}], {tmp", $val_modifier, "}"),
+                        dst = inout(reg) dst => _,
+                        val = in(reg) val,
+                        out = inout(reg) out_ptr => _,
+                        tmp = lateout($val_reg) _,
+                        options(nostack, preserves_flags),
+                    );
+                }
+                out
+            }
+        }
+        #[cfg(not(all(target_arch = "x86", atomic_maybe_uninit_no_cmpxchg)))]
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                //
+                // Refs: https://www.felixcloutier.com/x86/cmpxchg
+                unsafe {
+                    let r: u8;
+                    // compare_exchange is always SeqCst.
+                    asm!(
+                        // load from old/new to $cmpxchg_cmp_reg/tmp_new
+                        concat!("mov ", $cmpxchg_cmp_reg, ", ", $ptr_size, " ptr [{old", ptr_modifier!(), "}]"),
+                        concat!("mov {tmp_new", $val_modifier, "}, ", $ptr_size, " ptr [{new", ptr_modifier!(), "}]"),
+                        // (atomic) CAS
+                        // - Compare $cmpxchg_cmp_reg with dst.
+                        // - If equal, ZF is set and tmp_new is loaded into dst.
+                        // - Else, clear ZF and load dst into $cmpxchg_cmp_reg.
+                        concat!("lock cmpxchg ", $ptr_size, " ptr [{dst", ptr_modifier!(), "}], {tmp_new", $val_modifier, "}"),
+                        // load ZF to r
+                        "sete {r}",
+                        // store $cmpxchg_cmp_reg to out
+                        concat!("mov ", $ptr_size, " ptr [{out", ptr_modifier!(), "}], ", $cmpxchg_cmp_reg, ""),
+                        dst = in(reg) dst,
+                        old = in(reg) old,
+                        new = in(reg) new,
+                        out = in(reg) out_ptr,
+                        tmp_new = out($val_reg) _,
+                        r = out(reg_byte) r,
+                        out($cmpxchg_cmp_reg) _,
+                        // Do not use `preserves_flags` because CMPXCHG modifies the ZF flag.
+                        options(nostack),
+                    );
+                    debug_assert!(r == 0 || r == 1, "r={}", r);
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+atomic!(i8, reg_byte, "", "byte", "al");
+atomic!(u8, reg_byte, "", "byte", "al");
+atomic!(i16, reg, ":x", "word", "ax");
+atomic!(u16, reg, ":x", "word", "ax");
+atomic!(i32, reg, ":e", "dword", "eax");
+atomic!(u32, reg, ":e", "dword", "eax");
+#[cfg(target_arch = "x86_64")]
+atomic!(i64, reg, "", "qword", "rax");
+#[cfg(target_arch = "x86_64")]
+atomic!(u64, reg, "", "qword", "rax");
+#[cfg(target_pointer_width = "32")]
+atomic!(isize, reg, ":e", "dword", "eax");
+#[cfg(target_pointer_width = "32")]
+atomic!(usize, reg, ":e", "dword", "eax");
+#[cfg(target_pointer_width = "64")]
+atomic!(isize, reg, "", "qword", "rax");
+#[cfg(target_pointer_width = "64")]
+atomic!(usize, reg, "", "qword", "rax");
+
+// For load/store, we can use MOVQ(SSE2)/MOVLPS(SSE) instead of CMPXCHG8B.
+// Refs: https://github.com/llvm/llvm-project/blob/llvmorg-17.0.0-rc2/llvm/test/CodeGen/X86/atomic-load-store-wide.ll
+#[cfg(target_arch = "x86")]
+#[cfg(not(atomic_maybe_uninit_no_cmpxchg8b))]
+macro_rules! atomic64 {
+    ($int_type:ident) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                #[cfg(target_feature = "sse")]
+                // SAFETY: the caller must uphold the safety contract.
+                // cfg guarantees that the CPU supports SSE.
+                unsafe {
+                    #[cfg(target_feature = "sse2")]
+                    {
+                        // atomic load is always SeqCst.
+                        asm!(
+                            // Refs:
+                            // - https://www.felixcloutier.com/x86/movq (SSE2)
+                            // - https://www.felixcloutier.com/x86/movd:movq (SSE2)
+                            // - https://www.felixcloutier.com/x86/pshufd (SSE2)
+                            // (atomic) load from src to tmp0
+                            "movq {tmp0}, qword ptr [{src}]",
+                            // extract lower 64-bits
+                            "pshufd {tmp1}, {tmp0}, 85",
+                            // store tmp0/tmp1 to out
+                            "movd dword ptr [{out}], {tmp0}",
+                            "movd dword ptr [{out} + 4], {tmp1}",
+                            src = in(reg) src,
+                            out = in(reg) out_ptr,
+                            tmp0 = out(xmm_reg) _,
+                            tmp1 = out(xmm_reg) _,
+                            options(nostack, preserves_flags),
+                        );
+                    }
+                    #[cfg(not(target_feature = "sse2"))]
+                    {
+                        // atomic load is always SeqCst.
+                        asm!(
+                            // Refs:
+                            // - https://www.felixcloutier.com/x86/xorps (SSE)
+                            // - https://www.felixcloutier.com/x86/movlps (SSE)
+                            // - https://www.felixcloutier.com/x86/movss (SSE)
+                            // - https://www.felixcloutier.com/x86/shufps (SSE)
+                            "xorps {tmp}, {tmp}",
+                            // (atomic) load from src to tmp
+                            "movlps {tmp}, qword ptr [{src}]",
+                            // store tmp to out
+                            "movss dword ptr [{out}], {tmp}",
+                            "shufps {tmp}, {tmp}, 85",
+                            "movss dword ptr [{out} + 4], {tmp}",
+                            src = in(reg) src,
+                            out = in(reg) out_ptr,
+                            tmp = out(xmm_reg) _,
+                            options(nostack, preserves_flags),
+                        );
+                    }
+                }
+                #[cfg(not(target_feature = "sse"))]
+                // SAFETY: the caller must uphold the safety contract.
+                //
+                // Refs: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
+                unsafe {
+                    // atomic load is always SeqCst.
+                    asm!(
+                        // esi is reserved by LLVM
+                        "xchg {esi_tmp}, esi",
+                        // (atomic) load by cmpxchg(0, 0)
+                        "lock cmpxchg8b qword ptr [edi]",
+                        // store current value to out
+                        "mov dword ptr [esi], eax",
+                        "mov dword ptr [esi + 4], edx",
+                        "mov esi, {esi_tmp}", // restore esi
+                        esi_tmp = inout(reg) out_ptr => _,
+                        // set old/new args of cmpxchg8b to 0
+                        inout("eax") 0_u32 => _,
+                        inout("edx") 0_u32 => _,
+                        in("ebx") 0_u32,
+                        in("ecx") 0_u32,
+                        in("edi") src,
+                        // Do not use `preserves_flags` because CMPXCHG8B modifies the ZF flag.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                #[cfg(target_feature = "sse")]
+                // SAFETY: the caller must uphold the safety contract.
+                // cfg guarantees that the CPU supports SSE.
+                //
+                // Refs:
+                // - https://www.felixcloutier.com/x86/movlps (SSE)
+                // - https://www.felixcloutier.com/x86/xorps (SSE)
+                // - https://www.felixcloutier.com/x86/movsd (SSE2)
+                // - https://www.felixcloutier.com/x86/lock
+                // - https://www.felixcloutier.com/x86/or
+                unsafe {
+                    match order {
+                        // Relaxed and Release stores are equivalent.
+                        Ordering::Relaxed | Ordering::Release => {
+                            asm!(
+                                if_sse2!("", "xorps {tmp}, {tmp}"),
+                                // load from val to tmp
+                                if_sse2!("movsd {tmp}, qword ptr [{val}]", "movlps {tmp}, qword ptr [{val}]"),
+                                // (atomic) store tmp to dst
+                                "movlps qword ptr [{dst}], {tmp}",
+                                dst = in(reg) dst,
+                                val = in(reg) val,
+                                tmp = out(xmm_reg) _,
+                                options(nostack, preserves_flags),
+                            );
+                        }
+                        Ordering::SeqCst => {
+                            let p = core::cell::UnsafeCell::new(0_u32);
+                            asm!(
+                                // load from val to tmp
+                                if_sse2!("", "xorps {tmp}, {tmp}"),
+                                if_sse2!("movsd {tmp}, qword ptr [{val}]", "movlps {tmp}, qword ptr [{val}]"),
+                                // (atomic) store tmp to dst
+                                "movlps qword ptr [{dst}], {tmp}",
+                                "lock or dword ptr [{p}], 0", // equivalent to mfence, but doesn't require SSE2
+                                dst = in(reg) dst,
+                                val = in(reg) val,
+                                tmp = out(xmm_reg) _,
+                                p = in(reg) p.get(),
+                                // Do not use `preserves_flags` because OR modifies the OF, CF, SF, ZF, and PF flags.
+                                options(nostack),
+                            );
+                        }
+                        _ => unreachable!("{:?}", order),
+                    }
+                }
+                #[cfg(not(target_feature = "sse"))]
+                // SAFETY: the caller must uphold the safety contract.
+                //
+                // Refs: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
+                unsafe {
+                    // atomic store is always SeqCst.
+                    let _ = order;
+                    asm!(
+                        "mov ebx, dword ptr [eax]",
+                        "mov ecx, dword ptr [eax + 4]",
+                        // This is based on the code generated for the first load in DW RMWs by LLVM,
+                        // but it is interesting that they generate code that does mixed-sized atomic access.
+                        //
+                        // This is not single-copy atomic reads, but this is ok because subsequent
+                        // CAS will check for consistency.
+                        "mov eax, dword ptr [edi]",
+                        "mov edx, dword ptr [edi + 4]",
+                        // (atomic) store (CAS loop)
+                        "2:",
+                            "lock cmpxchg8b qword ptr [edi]",
+                            "jne 2b",
+                        inout("eax") val => _,
+                        out("edx") _,
+                        out("ebx") _,
+                        out("ecx") _,
+                        in("edi") dst,
+                        // Do not use `preserves_flags` because CMPXCHG8B modifies the ZF flag.
+                        options(nostack),
+                    );
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                //
+                // Refs: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
+                unsafe {
+                    // atomic store is always SeqCst.
+                    asm!(
+                        // esi is reserved by LLVM
+                        "xchg {esi_tmp}, esi",
+                        "mov ebx, dword ptr [eax]",
+                        "mov ecx, dword ptr [eax + 4]",
+                        // This is based on the code generated for the first load in DW RMWs by LLVM,
+                        // but it is interesting that they generate code that does mixed-sized atomic access.
+                        //
+                        // This is not single-copy atomic reads, but this is ok because subsequent
+                        // CAS will check for consistency.
+                        "mov eax, dword ptr [edi]",
+                        "mov edx, dword ptr [edi + 4]",
+                        // (atomic) swap (CAS loop)
+                        "2:",
+                            "lock cmpxchg8b qword ptr [edi]",
+                            "jne 2b",
+                        // store previous value to out
+                        "mov dword ptr [esi], eax",
+                        "mov dword ptr [esi + 4], edx",
+                        "mov esi, {esi_tmp}", // restore esi
+                        esi_tmp = inout(reg) out_ptr => _,
+                        inout("eax") val => _,
+                        out("edx") _,
+                        out("ebx") _,
+                        out("ecx") _,
+                        in("edi") dst,
+                        // Do not use `preserves_flags` because CMPXCHG8B modifies the ZF flag.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must uphold the safety contract.
+                //
+                // Refs: https://www.felixcloutier.com/x86/cmpxchg
+                unsafe {
+                    let mut r: u32;
+                    // compare_exchange is always SeqCst.
+                    asm!(
+                        // esi is reserved by LLVM
+                        "xchg {esi_tmp}, esi",
+                        "mov eax, dword ptr [edx]",
+                        "mov edx, dword ptr [edx + 4]",
+                        "mov ebx, dword ptr [ecx]",
+                        "mov ecx, dword ptr [ecx + 4]",
+                        // (atomic) CAS
+                        "lock cmpxchg8b qword ptr [edi]",
+                        "sete cl",
+                        // store previous value to out
+                        "mov dword ptr [esi], eax",
+                        "mov dword ptr [esi + 4], edx",
+                        "mov esi, {esi_tmp}", // restore esi
+                        esi_tmp = inout(reg) out_ptr => _,
+                        out("eax") _,
+                        inout("edx") old => _,
+                        out("ebx") _,
+                        inout("ecx") new => r,
+                        in("edi") dst,
+                        // Do not use `preserves_flags` because CMPXCHG8B modifies the ZF flag.
+                        options(nostack),
+                    );
+                    debug_assert!(r as u8 == 0 || r as u8 == 1, "r={}", r as u8);
+                    (out, r as u8 != 0)
+                }
+            }
+        }
+    };
+}
+
+#[cfg(target_arch = "x86")]
+#[cfg(not(atomic_maybe_uninit_no_cmpxchg8b))]
+atomic64!(i64);
+#[cfg(target_arch = "x86")]
+#[cfg(not(atomic_maybe_uninit_no_cmpxchg8b))]
+atomic64!(u64);
+
+#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_feature = "cmpxchg16b", atomic_maybe_uninit_target_feature = "cmpxchg16b"))]
+macro_rules! atomic128 {
+    ($int_type:ident) => {
+        #[cfg(target_pointer_width = "32")]
+        atomic128!($int_type, "edi", "esi", "r8d", "edx");
+        #[cfg(target_pointer_width = "64")]
+        atomic128!($int_type, "rdi", "rsi", "r8", "rdx");
+    };
+    ($int_type:ident, $rdi:tt, $rsi:tt, $r8:tt, $rdx:tt) => {
+        impl AtomicLoad for $int_type {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(src as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+
+                // SAFETY: the caller must guarantee that `src` is valid for both writes and
+                // reads, 16-byte aligned, and that there are no concurrent non-atomic operations.
+                // cfg guarantees that the CPU supports CMPXCHG16B.
+                //
+                // If the value at `dst` (destination operand) and rdx:rax are equal, the
+                // 128-bit value in rcx:rbx is stored in the `dst`, otherwise the value at
+                // `dst` is loaded to rdx:rax.
+                //
+                // The ZF flag is set if the value at `dst` and rdx:rax are equal,
+                // otherwise it is cleared. Other flags are unaffected.
+                //
+                // Refs: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
+                unsafe {
+                    // atomic load is always SeqCst.
+                    asm!(
+                        // rbx is reserved by LLVM
+                        "mov {rbx_tmp}, rbx",
+                        "xor rbx, rbx", // zeroed rbx
+                        // (atomic) load by cmpxchg(0, 0)
+                        concat!("lock cmpxchg16b xmmword ptr [", $rdi, "]"),
+                        // store current value to out
+                        concat!("mov qword ptr [", $rsi, "], rax"),
+                        concat!("mov qword ptr [", $rsi, " + 8], rdx"),
+                        "mov rbx, {rbx_tmp}", // restore rbx
+                        // set old/new args of cmpxchg16b to 0 (rbx is zeroed after saved to rbx_tmp, to avoid xchg)
+                        rbx_tmp = out(reg) _,
+                        in("rcx") 0_u64,
+                        inout("rax") 0_u64 => _,
+                        inout("rdx") 0_u64 => _,
+                        in($rdi) src,
+                        in($rsi) out_ptr,
+                        // Do not use `preserves_flags` because CMPXCHG16B modifies the ZF flag.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicStore for $int_type {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must guarantee that `dst` is valid for both writes and
+                // reads, 16-byte aligned, and that there are no concurrent non-atomic operations.
+                // cfg guarantees that the CPU supports CMPXCHG16B.
+                //
+                // If the value at `dst` (destination operand) and rdx:rax are equal, the
+                // 128-bit value in rcx:rbx is stored in the `dst`, otherwise the value at
+                // `dst` is loaded to rdx:rax.
+                //
+                // The ZF flag is set if the value at `dst` and rdx:rax are equal,
+                // otherwise it is cleared. Other flags are unaffected.
+                //
+                // Refs: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
+                unsafe {
+                    // atomic store is always SeqCst.
+                    asm!(
+                        // rbx is reserved by LLVM
+                        "mov {rbx_tmp}, rbx",
+                        concat!("mov rbx, qword ptr [", $rsi, "]"),
+                        concat!("mov rcx, qword ptr [", $rsi, " + 8]"),
+                        // This is based on the code generated for the first load in DW RMWs by LLVM,
+                        // but it is interesting that they generate code that does mixed-sized atomic access.
+                        //
+                        // This is not single-copy atomic reads, but this is ok because subsequent
+                        // CAS will check for consistency.
+                        concat!("mov rax, qword ptr [", $rdi, "]"),
+                        concat!("mov rdx, qword ptr [", $rdi, " + 8]"),
+                        // (atomic) store (CAS loop)
+                        "2:",
+                            concat!("lock cmpxchg16b xmmword ptr [", $rdi, "]"),
+                            "jne 2b",
+                        "mov rbx, {rbx_tmp}", // restore rbx
+                        rbx_tmp = out(reg) _,
+                        out("rax") _,
+                        out("rcx") _,
+                        out("rdx") _,
+                        in($rdi) dst,
+                        in($rsi) val,
+                        // Do not use `preserves_flags` because CMPXCHG16B modifies the ZF flag.
+                        options(nostack),
+                    );
+                }
+            }
+        }
+        impl AtomicSwap for $int_type {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                _order: Ordering,
+            ) -> MaybeUninit<Self> {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let val = val.as_ptr();
+
+                // SAFETY: the caller must guarantee that `dst` is valid for both writes and
+                // reads, 16-byte aligned, and that there are no concurrent non-atomic operations.
+                // cfg guarantees that the CPU supports CMPXCHG16B.
+                //
+                // If the value at `dst` (destination operand) and rdx:rax are equal, the
+                // 128-bit value in rcx:rbx is stored in the `dst`, otherwise the value at
+                // `dst` is loaded to rdx:rax.
+                //
+                // The ZF flag is set if the value at `dst` and rdx:rax are equal,
+                // otherwise it is cleared. Other flags are unaffected.
+                //
+                // Refs: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
+                unsafe {
+                    // atomic swap is always SeqCst.
+                    asm!(
+                        // rbx is reserved by LLVM
+                        "mov {rbx_tmp}, rbx",
+                        concat!("mov rbx, qword ptr [", $rsi, "]"),
+                        concat!("mov rcx, qword ptr [", $rsi, " + 8]"),
+                        // This is based on the code generated for the first load in DW RMWs by LLVM,
+                        // but it is interesting that they generate code that does mixed-sized atomic access.
+                        //
+                        // This is not single-copy atomic reads, but this is ok because subsequent
+                        // CAS will check for consistency.
+                        concat!("mov rax, qword ptr [", $rdi, "]"),
+                        concat!("mov rdx, qword ptr [", $rdi, " + 8]"),
+                        // (atomic) swap (CAS loop)
+                        "2:",
+                            concat!("lock cmpxchg16b xmmword ptr [", $rdi, "]"),
+                            "jne 2b",
+                        // store previous value to out
+                        concat!("mov qword ptr [", $r8, "], rax"),
+                        concat!("mov qword ptr [", $r8, " + 8], rdx"),
+                        "mov rbx, {rbx_tmp}", // restore rbx
+                        rbx_tmp = out(reg) _,
+                        out("rax") _,
+                        out("rcx") _,
+                        out("rdx") _,
+                        in($rdi) dst,
+                        in($rsi) val,
+                        in($r8) out_ptr,
+                        // Do not use `preserves_flags` because CMPXCHG16B modifies the ZF flag.
+                        options(nostack),
+                    );
+                }
+                out
+            }
+        }
+        impl AtomicCompareExchange for $int_type {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                _success: Ordering,
+                _failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                debug_assert!(dst as usize % mem::size_of::<$int_type>() == 0);
+                let mut out: MaybeUninit<Self> = MaybeUninit::uninit();
+                let out_ptr = out.as_mut_ptr();
+                let old = old.as_ptr();
+                let new = new.as_ptr();
+
+                // SAFETY: the caller must guarantee that `dst` is valid for both writes and
+                // reads, 16-byte aligned, and that there are no concurrent non-atomic operations.
+                // cfg guarantees that the CPU supports CMPXCHG16B.
+                //
+                // If the value at `dst` (destination operand) and rdx:rax are equal, the
+                // 128-bit value in rcx:rbx is stored in the `dst`, otherwise the value at
+                // `dst` is loaded to rdx:rax.
+                //
+                // The ZF flag is set if the value at `dst` and rdx:rax are equal,
+                // otherwise it is cleared. Other flags are unaffected.
+                //
+                // Refs: https://www.felixcloutier.com/x86/cmpxchg8b:cmpxchg16b
+                unsafe {
+                    let mut r: u64;
+                    // compare_exchange is always SeqCst.
+                    asm!(
+                        // rbx is reserved by LLVM
+                        "mov {rbx_tmp}, rbx",
+                        concat!("mov rax, qword ptr [", $rsi, "]"),
+                        concat!("mov rsi, qword ptr [", $rsi, " + 8]"),
+                        concat!("mov rbx, qword ptr [", $rdx, "]"),
+                        concat!("mov rcx, qword ptr [", $rdx, " + 8]"),
+                        "mov rdx, rsi",
+                        // (atomic) CAS
+                        concat!("lock cmpxchg16b xmmword ptr [", $rdi, "]"),
+                        "sete cl",
+                        // store previous value to out
+                        concat!("mov qword ptr [", $r8, "], rax"),
+                        concat!("mov qword ptr [", $r8, " + 8], rdx"),
+                        "mov rbx, {rbx_tmp}", // restore rbx
+                        rbx_tmp = out(reg) _,
+                        out("rax") _,
+                        out("rcx") r,
+                        lateout("rdx") _,
+                        lateout("rsi") _,
+                        in($rdi) dst,
+                        in($rsi) old,
+                        in($rdx) new,
+                        in($r8) out_ptr,
+                        // Do not use `preserves_flags` because CMPXCHG16B modifies the ZF flag.
+                        options(nostack),
+                    );
+                    debug_assert!(r as u8 == 0 || r as u8 == 1, "r={}", r as u8);
+                    (out, r as u8 != 0)
+                }
+            }
+        }
+    };
+}
+
+#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_feature = "cmpxchg16b", atomic_maybe_uninit_target_feature = "cmpxchg16b"))]
+atomic128!(i128);
+#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_feature = "cmpxchg16b", atomic_maybe_uninit_target_feature = "cmpxchg16b"))]
+atomic128!(u128);
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(not(all(
+    target_arch = "x86_64",
+    any(target_feature = "cmpxchg16b", atomic_maybe_uninit_target_feature = "cmpxchg16b"),
+)))]
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[cfg(not(all(
+    target_arch = "x86_64",
+    any(target_feature = "cmpxchg16b", atomic_maybe_uninit_target_feature = "cmpxchg16b"),
+)))]
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(all(
+    target_arch = "x86_64",
+    any(target_feature = "cmpxchg16b", atomic_maybe_uninit_target_feature = "cmpxchg16b"),
+))]
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(all(
+    target_arch = "x86_64",
+    any(target_feature = "cmpxchg16b", atomic_maybe_uninit_target_feature = "cmpxchg16b"),
+))]
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ mod utils;
 #[macro_use]
 mod tests;
 
+#[cfg_attr(atomic_maybe_uninit_no_asm_maybe_uninit, path = "arch_legacy/mod.rs")]
 mod arch;
 
 pub mod raw;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,10 @@
 #[path = "gen/utils.rs"]
 mod gen;
 
-use core::sync::atomic::Ordering;
+use core::{
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
 
 macro_rules! static_assert {
     ($cond:expr $(, $($msg:tt)*)?) => {
@@ -86,5 +89,163 @@ pub(crate) fn upgrade_success_ordering(success: Ordering, failure: Ordering) -> 
         (Ordering::Release, Ordering::Acquire) => Ordering::AcqRel,
         (_, Ordering::SeqCst) => Ordering::SeqCst,
         _ => success,
+    }
+}
+
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn zero_extend<T: ZeroExtend>(v: MaybeUninit<T>) -> T::Out {
+    T::zero_extend(v)
+}
+pub(crate) trait ZeroExtend: Copy {
+    type Out: Copy;
+    fn zero_extend(v: MaybeUninit<Self>) -> Self::Out;
+}
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct ZeroExtend8 {
+    #[cfg(target_endian = "big")]
+    pad: [u8; 3],
+    v: MaybeUninit<u8>,
+    #[cfg(target_endian = "little")]
+    pad: [u8; 3],
+}
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct ZeroExtend16 {
+    #[cfg(target_endian = "big")]
+    pad: u16,
+    v: MaybeUninit<u16>,
+    #[cfg(target_endian = "little")]
+    pad: u16,
+}
+macro_rules! zero_extend {
+    (8; $ty:ident) => {
+        impl ZeroExtend for $ty {
+            type Out = MaybeUninit<u32>;
+            #[inline]
+            fn zero_extend(v: MaybeUninit<$ty>) -> Self::Out {
+                #[allow(clippy::useless_transmute)]
+                // SAFETY: we can safely transmute any 32-bit value to MaybeUninit<u32>.
+                unsafe {
+                    mem::transmute(ZeroExtend8 { v: mem::transmute(v), pad: [0; 3] })
+                }
+            }
+        }
+    };
+    (16; $ty:ident) => {
+        impl ZeroExtend for $ty {
+            type Out = MaybeUninit<u32>;
+            #[inline]
+            fn zero_extend(v: MaybeUninit<$ty>) -> Self::Out {
+                #[allow(clippy::useless_transmute)]
+                // SAFETY: we can safely transmute any 32-bit value to MaybeUninit<u32>.
+                unsafe {
+                    mem::transmute(ZeroExtend16 { v: mem::transmute(v), pad: 0 })
+                }
+            }
+        }
+    };
+    ($ty:ident) => {
+        impl ZeroExtend for $ty {
+            type Out = MaybeUninit<$ty>;
+            #[inline]
+            fn zero_extend(v: MaybeUninit<$ty>) -> Self::Out {
+                v
+            }
+        }
+    };
+}
+zero_extend!(8; i8);
+zero_extend!(8; u8);
+zero_extend!(16; i16);
+zero_extend!(16; u16);
+zero_extend!(i32);
+zero_extend!(u32);
+zero_extend!(i64);
+zero_extend!(u64);
+zero_extend!(isize);
+zero_extend!(usize);
+
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64",
+    target_arch = "s390x",
+    target_arch = "x86_64",
+))]
+pub(crate) use imp::Pair128 as Pair;
+#[allow(dead_code)]
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64",
+    target_arch = "s390x",
+    target_arch = "x86_64",
+))]
+/// A 128-bit value represented as a pair of 64-bit values.
+///
+/// This type is `#[repr(C)]`, both fields have the same in-memory representation
+/// and are plain old data types, so access to the fields is always safe.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub(crate) union MaybeUninit128 {
+    pub(crate) u128: MaybeUninit<u128>,
+    pub(crate) i128: MaybeUninit<i128>,
+    pub(crate) pair: Pair,
+}
+
+#[cfg(any(target_arch = "arm", target_arch = "hexagon", target_arch = "x86"))]
+pub(crate) use imp::Pair64 as Pair;
+#[allow(dead_code)]
+#[cfg(any(target_arch = "arm", target_arch = "hexagon", target_arch = "x86"))]
+/// A 64-bit value represented as a pair of 32-bit values.
+///
+/// This type is `#[repr(C)]`, both fields have the same in-memory representation
+/// and are plain old data types, so access to the fields is always safe.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub(crate) union MaybeUninit64 {
+    pub(crate) u64: MaybeUninit<u64>,
+    pub(crate) i64: MaybeUninit<i64>,
+    pub(crate) pair: Pair,
+}
+
+// little endian order
+#[allow(dead_code)]
+#[cfg(any(target_endian = "little", target_arch = "aarch64", target_arch = "arm"))]
+mod imp {
+    use core::mem::MaybeUninit;
+    // A pair of 32-bit values.
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    pub(crate) struct Pair64 {
+        pub(crate) lo: MaybeUninit<u32>,
+        pub(crate) hi: MaybeUninit<u32>,
+    }
+    // A pair of 64-bit values.
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    pub(crate) struct Pair128 {
+        pub(crate) lo: MaybeUninit<u64>,
+        pub(crate) hi: MaybeUninit<u64>,
+    }
+}
+// big endian order
+#[allow(dead_code)]
+#[cfg(not(any(target_endian = "little", target_arch = "aarch64", target_arch = "arm")))]
+mod imp {
+    use core::mem::MaybeUninit;
+    // A pair of 32-bit values.
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    pub(crate) struct Pair64 {
+        pub(crate) hi: MaybeUninit<u32>,
+        pub(crate) lo: MaybeUninit<u32>,
+    }
+    // A pair of 64-bit values.
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    pub(crate) struct Pair128 {
+        pub(crate) hi: MaybeUninit<u64>,
+        pub(crate) lo: MaybeUninit<u64>,
     }
 }

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -128,7 +128,9 @@ default_targets=(
     # rustc --print target-list | grep -E '^hexagon'
     hexagon-unknown-linux-musl
 )
-known_cfgs=()
+known_cfgs=(
+    atomic_maybe_uninit_use_cp15_barrier
+)
 
 x() {
     local cmd="$1"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -53,7 +53,7 @@ default_targets=(
     armv7-unknown-linux-gnueabihf
     thumbv7neon-unknown-linux-gnueabihf
     # armv7-a big endian
-    armebv7-unknown-linux-gnueabi
+    armebv7-unknown-linux-gnueabi # custom target
     # armv8-a
     armv8a-none-eabi # custom target
     # armv8-a big endian


### PR DESCRIPTION
Update codebase to use MaybeUninit registers now supported by https://github.com/rust-lang/rust/pull/114790.

This greatly improves performance and is almost equivalent to std atomic types (https://github.com/crossbeam-rs/crossbeam/pull/1015#issuecomment-1676549870).

In older rustc versions, fallback to the previous implementation (copied to `arch_legacy` module).
