### PR TITLE
m68k: Support swap/CAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Currently, x86, x86_64, Arm, AArch64, RISC-V, LoongArch64, MIPS32, MIPS64, Power
 | msp430 \[4] (experimental)       | isize,usize,i8,u8,i16,u16                           | ✓          | ✓        |
 | avr \[4] (experimental)          | isize,usize,i8,u8,i16,u16                           | ✓          | ✓        |
 | hexagon \[4] (experimental)      | isize,usize,i8,u8,i16,u16,i32,u32,i64,u64           | ✓          | ✓        |
-| m68k \[4] (experimental)         | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          |          |
+| m68k \[4] (experimental)         | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          | ✓\[1]    |
 | xtensa \[4] (experimental)       | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          |          |
 
-\[1] Arm's atomic RMW operations are not available on v6-m (thumbv6m). RISC-V's atomic RMW operations are not available on targets without the A (or G which means IMAFD) extension such as riscv32i, riscv32imc, etc.<br>
+\[1] Arm's atomic RMW operations are not available on v6-m (thumbv6m). RISC-V's atomic RMW operations are not available on targets without the A (or G which means IMAFD) extension such as riscv32i, riscv32imc, etc. M68k's atomic RMW operations requires M68020+ (Linux is M68020+ by default).<br>
 \[2] Armv6+ or Linux/Android, except for M-profile architecture such as thumbv6m, thumbv7m, etc.<br>
 \[3] Requires Rust 1.72+.<br>
 \[4] Requires nightly due to `#![feature(asm_experimental_arch)]`.<br>

--- a/src/arch/cfgs/m68k.rs
+++ b/src/arch/cfgs/m68k.rs
@@ -42,10 +42,22 @@ macro_rules! cfg_has_atomic_128 {
 macro_rules! cfg_no_atomic_128 {
     ($($tt:tt)*) => { $($tt)* };
 }
+#[cfg(any(target_feature = "isa-68020", atomic_maybe_uninit_target_feature = "isa-68020"))]
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(any(target_feature = "isa-68020", atomic_maybe_uninit_target_feature = "isa-68020"))]
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}
+#[cfg(not(any(target_feature = "isa-68020", atomic_maybe_uninit_target_feature = "isa-68020")))]
 #[macro_export]
 macro_rules! cfg_has_atomic_cas {
     ($($tt:tt)*) => {};
 }
+#[cfg(not(any(target_feature = "isa-68020", atomic_maybe_uninit_target_feature = "isa-68020")))]
 #[macro_export]
 macro_rules! cfg_no_atomic_cas {
     ($($tt:tt)*) => { $($tt)* };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@ Currently, x86, x86_64, Arm, AArch64, RISC-V, LoongArch64, MIPS32, MIPS64, Power
 | msp430 \[4] (experimental)       | isize,usize,i8,u8,i16,u16                           | ✓          | ✓        |
 | avr \[4] (experimental)          | isize,usize,i8,u8,i16,u16                           | ✓          | ✓        |
 | hexagon \[4] (experimental)      | isize,usize,i8,u8,i16,u16,i32,u32,i64,u64           | ✓          | ✓        |
-| m68k \[4] (experimental)         | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          |          |
+| m68k \[4] (experimental)         | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          | ✓\[1]    |
 | xtensa \[4] (experimental)       | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          |          |
 
-\[1] Arm's atomic RMW operations are not available on v6-m (thumbv6m). RISC-V's atomic RMW operations are not available on targets without the A (or G which means IMAFD) extension such as riscv32i, riscv32imc, etc.<br>
+\[1] Arm's atomic RMW operations are not available on v6-m (thumbv6m). RISC-V's atomic RMW operations are not available on targets without the A (or G which means IMAFD) extension such as riscv32i, riscv32imc, etc. M68k's atomic RMW operations requires M68020+ (Linux is M68020+ by default).<br>
 \[2] Armv6+ or Linux/Android, except for M-profile architecture such as thumbv6m, thumbv7m, etc.<br>
 \[3] Requires Rust 1.72+.<br>
 \[4] Requires nightly due to `#![feature(asm_experimental_arch)]`.<br>


### PR DESCRIPTION
64-bit atomics cannot be supported yet due LLVM 19 doesn't seem to support cas2 instruction.

```
error: unexpected token parsing operands
  |
note: instantiated into assembly here
 --> <inline asm>:4:8
  |
4 | cas2.l %d2:%d3, %d1:%d0, (%a0):(%a1)
  |        ^
```