### PR TITLE
Cleanup and comment improvements

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -2,7 +2,6 @@ addi
 amoswap
 amswap
 andc
-andi
 andn
 aqrl
 armasm
@@ -24,7 +23,6 @@ espup
 fild
 fistp
 getex
-Halfword
 IMAFD
 inequal
 ishld
@@ -84,7 +82,6 @@ signedness
 simavr
 simio
 sllv
-sltiu
 sltui
 sreg
 srlv
@@ -113,4 +110,5 @@ xorps
 zaamo
 zabha
 zacas
+zalasr
 zalrsc

--- a/src/gen/utils.rs
+++ b/src/gen/utils.rs
@@ -46,6 +46,7 @@
 ))]
 #[macro_use]
 mod imp {
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     macro_rules! ptr_reg {
         ($ptr:ident) => {{
             let _: *const _ = $ptr; // ensure $ptr is a pointer (*mut _ or *const _)
@@ -87,6 +88,7 @@ mod imp {
 )))]
 #[macro_use]
 mod imp {
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     macro_rules! ptr_reg {
         ($ptr:ident) => {{
             let _: *const _ = $ptr; // ensure $ptr is a pointer (*mut _ or *const _)

--- a/tools/target_spec.sh
+++ b/tools/target_spec.sh
@@ -53,6 +53,7 @@ $(sed -E 's/^/        target_arch = "/g; s/$/",/g' <<<"${known_64_bit_arch[*]}")
 ))]
 #[macro_use]
 mod imp {
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     macro_rules! ptr_reg {
         (\$ptr:ident) => {{
             let _: *const _ = \$ptr; // ensure \$ptr is a pointer (*mut _ or *const _)
@@ -82,6 +83,7 @@ $(sed -E 's/^/        target_arch = "/g; s/$/",/g' <<<"${known_64_bit_arch[*]}")
 )))]
 #[macro_use]
 mod imp {
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     macro_rules! ptr_reg {
         (\$ptr:ident) => {{
             let _: *const _ = \$ptr; // ensure \$ptr is a pointer (*mut _ or *const _)


### PR DESCRIPTION
- Add per-line pseudo code style code comments to almost all inline assemblies. 
  Hopefully this will make the code easier to understand for people who are not familiar with assembly.
  For example:
  https://github.com/taiki-e/atomic-maybe-uninit/blob/d9019836be974e27878e71a7fc1f6dffd0cc5e4d/src/arch/powerpc.rs#L187-L192

- Add module-level comments to some architectures describing the types of atomic instructions provided by that architecture. I plan to add this for other architectures in the future.
  <details><summary>powerpc</summary>

  https://github.com/taiki-e/atomic-maybe-uninit/blob/d9019836be974e27878e71a7fc1f6dffd0cc5e4d/src/arch/powerpc.rs#L6-L23

  </details>
  <details><summary>riscv</summary>

  https://github.com/taiki-e/atomic-maybe-uninit/blob/d9019836be974e27878e71a7fc1f6dffd0cc5e4d/src/arch/riscv.rs#L6-L30

  </details>
  <details><summary>s390x</summary>

  https://github.com/taiki-e/atomic-maybe-uninit/blob/d9019836be974e27878e71a7fc1f6dffd0cc5e4d/src/arch/s390x.rs#L6-L22
  
  </details>

- Clean up suboptimal or redundant code found during the above process.
- Add links to generated assemblies for tier 3 targets.