### PR TITLE
Support C-SKY (experimental)

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -1,3 +1,4 @@
+abiv
 amocas
 amoswap
 amswap
@@ -18,10 +19,12 @@ ccmp
 cdsg
 CDSY
 clrex
+cmpne
 cmpw
 cmpxchg
 csel
 cset
+cskyv
 dbar
 distro
 DWCAS
@@ -44,6 +47,7 @@ ldar
 ldarx
 ldaxp
 ldclrp
+ldex
 ldiapp
 ldrex
 ldrexd
@@ -83,6 +87,7 @@ opensbi
 orrs
 partword
 pstq
+pthread
 qbsp
 quadword
 rcpc
@@ -106,6 +111,7 @@ sreg
 srlv
 stbar
 stdcx
+stex
 stilp
 stlxp
 stpq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,29 @@ jobs:
             target: armeb-unknown-linux-gnueabi
             os: ubuntu-22.04
           # ------------------------------------------------------------
+          # csky-unknown-linux-gnuabiv2
+          - rust: nightly-2025-02-14 # Rust 1.86, LLVM 19 (oldest version we can use asm_experimental_arch on this target)
+            target: csky-unknown-linux-gnuabiv2
+            # +crt-static: Workaround for C-SKY QEMU issue
+            # ldex/stex requires ck860*
+            flags: -C target-feature=+crt-static -C target-cpu=ck860
+          - rust: nightly
+            target: csky-unknown-linux-gnuabiv2
+            # +crt-static: Workaround for C-SKY QEMU issue
+            # ldex/stex requires ck860*
+            flags: -C target-feature=+crt-static -C target-cpu=ck860
+          # ------------------------------------------------------------
+          # csky-unknown-linux-gnuabiv2hf
+          # TODO: relocations in generic ELF (EM: 252)
+          # - rust: nightly-2025-02-14 # Rust 1.86, LLVM 19 (oldest version we can use asm_experimental_arch on this target)
+          #   target: csky-unknown-linux-gnuabiv2hf
+          #   # +crt-static: Workaround for C-SKY QEMU issue
+          #   flags: -C target-feature=+crt-static
+          # - rust: nightly
+          #   target: csky-unknown-linux-gnuabiv2hf
+          #   # +crt-static: Workaround for C-SKY QEMU issue
+          #   flags: -C target-feature=+crt-static
+          # ------------------------------------------------------------
           # hexagon-unknown-linux-musl
           - rust: nightly-2024-11-29 # Rust 1.85, LLVM 19 (oldest version we can use asm_experimental_arch on this target)
             target: hexagon-unknown-linux-musl
@@ -510,7 +533,34 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
-        if: steps.prepare.outputs.target-not-host == 'true'
+        if: steps.prepare.outputs.target-not-host == 'true' && !startsWith(matrix.target, 'csky-')
+      # TODO: not yet supported in setup-cross-toolchain-action
+      - run: |
+          retry() {
+            for i in {1..10}; do
+              if "$@"; then
+                return 0
+              else
+                sleep "${i}"
+              fi
+            done
+            "$@"
+          }
+          target="${{ matrix.target }}"
+          # https://github.com/taiki-e/rust-cross-toolchain/pkgs/container/rust-cross-toolchain
+          retry docker create --name gcc-csky-linux-gnuabiv2 "ghcr.io/taiki-e/rust-cross-toolchain:${target}-dev-amd64"
+          docker cp -- "gcc-csky-linux-gnuabiv2:/${target}" "${HOME}"/gcc-csky-linux-gnuabiv2
+          docker rm -f -- gcc-csky-linux-gnuabiv2 >/dev/null
+          printf '%s\n' "${HOME}"/gcc-csky-linux-gnuabiv2/bin >>"${GITHUB_PATH}"
+          printf '%s\n' "CARGO_TARGET_CSKY_UNKNOWN_LINUX_GNUABIV2_LINKER=csky-abiv2-linux-gcc" >>"${GITHUB_ENV}"
+          case "${target}" in
+            *hf) qemu_cpu=ck860fv ;;
+            # https://github.com/taiki-e/atomic-maybe-uninit/pull/32#issuecomment-3341287749
+            *) qemu_cpu=ck860 ;;
+          esac
+          printf '%s\n' "CARGO_TARGET_CSKY_UNKNOWN_LINUX_GNUABIV2_RUNNER=qemu-cskyv2 -cpu ${qemu_cpu}" >>"${GITHUB_ENV}"
+          printf 'BUILD_STD=-Z''build-std\n' >>"${GITHUB_ENV}"
+        if: startsWith(matrix.target, 'csky-')
       - run: |
           target="${{ matrix.target }}"
           target_lower="${target//-/_}"
@@ -525,7 +575,8 @@ jobs:
         if: matrix.flags != ''
       - run: printf '%s\n' "RUSTFLAGS=${RUSTFLAGS} -D linker_messages" >>"${GITHUB_ENV}"
         # TODO(macos): error: linker stderr: ld: ignoring duplicate libraries: '-lc', '-lm'
-        if: matrix.rust == 'nightly' && !contains(matrix.target, '-darwin')
+        # TODO(csky): error: linker stderr: /home/runner/gcc-csky-linux-gnuabiv2/bin/../lib/gcc/csky-linux-gnuabiv2/6.3.0/../../../../csky-linux-gnuabiv2/bin/ld: file ....o's arch flag ck860 conflict with target ck810,set target arch flag to ck860
+        if: matrix.rust == 'nightly' && !(contains(matrix.target, '-darwin') || matrix.target == 'csky-unknown-linux-gnuabiv2')
       # Old LLVM bug: Undefined temporary symbol error when building std.
       - name: Workaround for old LLVM bug about MIPS32
         run: printf 'RELEASE=--release\n' >>"${GITHUB_ENV}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ doc-scrape-examples = false
 [dev-dependencies]
 fastrand = "2"
 paste = "1"
-quickcheck = { version = "1", default-features = false, git = "https://github.com/taiki-e/quickcheck.git", rev = "83b1d59" } # https://github.com/BurntSushi/quickcheck/pull/304 + https://github.com/BurntSushi/quickcheck/pull/282 + https://github.com/BurntSushi/quickcheck/pull/296 + f16/f128 support + lower MSRV
+quickcheck = { version = "1", default-features = false, git = "https://github.com/taiki-e/quickcheck.git", rev = "f0c7237" } # https://github.com/BurntSushi/quickcheck/pull/304 + https://github.com/BurntSushi/quickcheck/pull/282 + https://github.com/BurntSushi/quickcheck/pull/296 + rand -> fastrand + lower MSRV
 
 [target.'cfg(valgrind)'.dev-dependencies]
 crabgrind = "0.1"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This crate provides a way to soundly perform such operations.
 
 ## Platform Support
 
-Currently, x86, x86_64, Arm, AArch64, RISC-V, LoongArch, Arm64EC, s390x, MIPS, PowerPC, MSP430, AVR, SPARC, Hexagon, M68k, and Xtensa are supported.
+Currently, x86, x86_64, Arm, AArch64, RISC-V, LoongArch, Arm64EC, s390x, MIPS, PowerPC, MSP430, AVR, SPARC, Hexagon, M68k, C-SKY, and Xtensa are supported.
 (You can use `cfg_{has,no}_*` macros to write code based on whether or not which size of primitives is available.)
 
 | target_arch                     | primitives                                          | load/store | swap/CAS |
@@ -50,9 +50,10 @@ Currently, x86, x86_64, Arm, AArch64, RISC-V, LoongArch, Arm64EC, s390x, MIPS, P
 | hexagon \[9] (experimental)     | isize,usize,i8,u8,i16,u16,i32,u32,i64,u64           | ✓          | ✓        |
 | m68k \[9] (experimental)        | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          | ✓\[1]    |
 | m68k (+isa-68020) \[9] \[10] (experimental) | i64,u64                                 | ✓          | ✓        |
+| csky \[9] (experimental)        | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          | ✓\[1]    |
 | xtensa \[9] (experimental)      | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          | ✓\[1]    |
 
-\[1] Arm's atomic RMW operations are not available on Armv6-M (thumbv6m). RISC-V's atomic RMW operations are not available on targets without the A (or G which means IMAFD) or Zalrsc or Zacas extension, such as riscv32i, riscv32imc, etc. M68k's atomic RMW operations requires target-cpu M68020+ (enabled by default on Linux). Xtensa's atomic RMW operations are not available on esp32s2.<br>
+\[1] Arm's atomic RMW operations are not available on Armv6-M (thumbv6m). RISC-V's atomic RMW operations are not available on targets without the A (or G which means IMAFD) or Zalrsc or Zacas extension, such as riscv32i, riscv32imc, etc. M68k's atomic RMW operations requires target-cpu M68020+ (enabled by default on Linux). C-SKY's atomic RMW operations requires target-cpu ck860\* (enabled by default on the hard-float target). Xtensa's atomic RMW operations are not available on esp32s2.<br>
 \[2] Requires `cmpxchg16b` target feature (enabled by default on Apple, Windows (except Windows 7), and Fuchsia targets).<br>
 \[3] Armv6+ or Linux/Android, except for M-profile architecture such as thumbv6m, thumbv7m, etc.<br>
 \[4] Requires `zacas` target feature.<br>

--- a/src/arch/README.md
+++ b/src/arch/README.md
@@ -8,6 +8,7 @@ This document describes the operations that are considered atomic by architectur
 - [AArch64](#aarch64)
 - [Arm](#arm)
 - [AVR](#avr)
+- [C-SKY](#c-sky)
 - [Hexagon](#hexagon)
 - [LoongArch](#loongarch)
 - [M68k](#m68k)
@@ -60,6 +61,13 @@ This architecture is always single-core and the following operations are atomic:
   However, pure operations that are not affected by compiler fences (Note: the correct interrupt
   disabling and restoring implementation must imply compiler fences, e.g., asm without nomem/readonly)
   may be moved out of the critical section by compiler optimizations.
+
+## C-SKY
+
+target_arch: csky<br>
+Implementation: [csky.rs](csky.rs)<br>
+
+TODO: reference and overview
 
 ## Hexagon
 

--- a/src/arch/csky.rs
+++ b/src/arch/csky.rs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/*
+C-SKY
+
+Refs:
+- CSKY Architecture user_guide
+  https://github.com/c-sky/csky-doc/blob/9f7121f7d40970ba5cc0f15716da033db2bb9d07/CSKY%20Architecture%20user_guide.pdf
+- Linux kernel's C-SKY atomic implementation
+  https://github.com/torvalds/linux/blob/v6.16/arch/csky/include/asm/atomic.h
+  https://github.com/torvalds/linux/blob/v6.16/arch/csky/include/asm/barrier.h
+  https://github.com/torvalds/linux/blob/v6.16/arch/csky/include/asm/cmpxchg.h
+
+Generated asm:
+- csky https://godbolt.org/z/jK4c68WeG
+*/
+
+#[cfg(atomic_maybe_uninit_no_ldex_stex)]
+delegate_size!(delegate_load_store);
+#[cfg(not(atomic_maybe_uninit_no_ldex_stex))]
+delegate_size!(delegate_all);
+
+use core::{
+    arch::asm,
+    mem::{self, MaybeUninit},
+    sync::atomic::Ordering,
+};
+
+#[cfg(not(atomic_maybe_uninit_no_ldex_stex))]
+use crate::raw::{AtomicCompareExchange, AtomicSwap};
+use crate::raw::{AtomicLoad, AtomicStore};
+
+macro_rules! atomic_rmw {
+    ($op:ident, $order:ident) => {
+        match $order {
+            Ordering::Relaxed => $op!("", ""),
+            Ordering::Acquire => $op!("sync32", ""),
+            Ordering::Release => $op!("", "sync32"),
+            Ordering::AcqRel | Ordering::SeqCst => $op!("sync32", "sync32"),
+            _ => unreachable!(),
+        }
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! atomic_load_store {
+    ($ty:ident, $suffix:tt) => {
+        #[cfg(atomic_maybe_uninit_no_ldex_stex)]
+        delegate_signed!(delegate_load_store, $ty);
+        #[cfg(not(atomic_maybe_uninit_no_ldex_stex))]
+        delegate_signed!(delegate_all, $ty);
+        impl AtomicLoad for $ty {
+            #[inline]
+            unsafe fn atomic_load(
+                src: *const MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                let out: MaybeUninit<Self>;
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! atomic_load {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                $release,                                          // fence
+                                concat!("ld32.", $suffix, " {out}, ({src}, 0x0)"), // atomic { out = *src }
+                                $acquire,                                          // fence
+                                src = in(reg) ptr_reg!(src),
+                                out = lateout(reg) out,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    match order {
+                        Ordering::Relaxed => atomic_load!("", ""),
+                        Ordering::Acquire => atomic_load!("sync32", ""),
+                        Ordering::SeqCst => atomic_load!("sync32", "sync32"),
+                        _ => unreachable!(),
+                    }
+                }
+                out
+            }
+        }
+        impl AtomicStore for $ty {
+            #[inline]
+            unsafe fn atomic_store(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) {
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! store {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                $release,                                          // fence
+                                concat!("st32.", $suffix, " {val}, ({dst}, 0x0)"), // atomic { *dst = val }
+                                $acquire,                                          // fence
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(reg) val,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(store, order);
+                }
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! atomic {
+    ($ty:ident) => {
+        atomic_load_store!($ty, "w");
+        #[cfg(not(atomic_maybe_uninit_no_ldex_stex))]
+        impl AtomicSwap for $ty {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                let mut out: MaybeUninit<Self>;
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                $release,                         // fence
+                                "2:", // 'retry:
+                                    "ldex32.w {out}, ({dst}, 0)", // atomic { out = *dst; EXCLUSIVE = dst }
+                                    "or32 {tmp}, {val}, {val}",   // tmp = val
+                                    "stex32.w {tmp}, ({dst}, 0)", // atomic { if EXCLUSIVE == dst { *dst = tmp; tmp = 1 } else { tmp = 0 }; EXCLUSIVE = None }
+                                    "bez32 {tmp}, 2b",            // if tmp == 0 { jump 'retry }
+                                $acquire,                         // fence
+                                dst = in(reg) ptr_reg!(dst),
+                                val = in(reg) val,
+                                out = out(reg) out,
+                                tmp = out(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        #[cfg(not(atomic_maybe_uninit_no_ldex_stex))]
+        impl AtomicCompareExchange for $ty {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let mut out: MaybeUninit<Self>;
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: u32 = 0;
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            asm!(
+                                $release,                         // fence
+                                "2:", // 'retry:
+                                    "ldex32.w {out}, ({dst}, 0)", // atomic { out = *dst; EXCLUSIVE = dst }
+                                    "cmpne32 {out}, {old}",       // if out != old { C = 1 } else { C = 0 }
+                                    "bt32 3f",                    // if C == 1 { jump 'cmp-fail }
+                                    "or32 {tmp}, {new}, {new}",   // tmp = new
+                                    "stex32.w {tmp}, ({dst}, 0)", // atomic { if EXCLUSIVE == dst { *dst = tmp; tmp = 1 } else { tmp = 0 }; EXCLUSIVE = None }
+                                    "bez32 {tmp}, 2b",            // if tmp == 0 { jump 'retry }
+                                "3:", // 'cmp-fail:
+                                $acquire,                         // fence
+                                dst = in(reg) ptr_reg!(dst),
+                                old = in(reg) old,
+                                new = in(reg) new,
+                                out = out(reg) out,
+                                tmp = inout(reg) r,
+                                // Do not use `preserves_flags` because CMPNE modifies condition bit C.
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg, order);
+                    crate::utils::assert_unchecked(r == 0 || r == 1); // may help remove extra test
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! atomic_sub_word {
+    ($ty:ident, $suffix:tt) => {
+        atomic_load_store!($ty, $suffix);
+        #[cfg(not(atomic_maybe_uninit_no_ldex_stex))]
+        impl AtomicSwap for $ty {
+            #[inline]
+            unsafe fn atomic_swap(
+                dst: *mut MaybeUninit<Self>,
+                val: MaybeUninit<Self>,
+                order: Ordering,
+            ) -> MaybeUninit<Self> {
+                let (dst, shift, mask) = crate::utils::create_sub_word_mask_values(dst);
+                let mut out: MaybeUninit<Self>;
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    macro_rules! swap {
+                        ($acquire:tt, $release:tt) => {
+                            // Implement sub-word atomic operations using word-sized LL/SC loop.
+                            // See also create_sub_word_mask_values.
+                            asm!(
+                                "lsl32 {val}, {val}, {shift}",     // val <<= shift
+                                $release,                          // fence
+                                "2:", // 'retry:
+                                    "ldex32.w {out}, ({dst}, 0)",  // atomic { out = *dst; EXCLUSIVE = dst }
+                                    "andn32 {tmp}, {out}, {mask}", // tmp = out & !mask
+                                    "or32 {tmp}, {tmp}, {val}",    // tmp |= val
+                                    "stex32.w {tmp}, ({dst}, 0)",  // atomic { if EXCLUSIVE == dst { *dst = tmp; tmp = 1 } else { tmp = 0 }; EXCLUSIVE = None }
+                                    "bez32 {tmp}, 2b",             // if tmp == 0 { jump 'retry }
+                                $acquire,                          // fence
+                                "lsr32 {out}, {out}, {shift}",     // out >>= shift
+                                dst = in(reg) ptr_reg!(dst),
+                                val = inout(reg) crate::utils::zero_extend32::$ty(val) => _,
+                                out = out(reg) out,
+                                shift = in(reg) shift,
+                                mask = in(reg) mask,
+                                tmp = out(reg) _,
+                                options(nostack, preserves_flags),
+                            )
+                        };
+                    }
+                    atomic_rmw!(swap, order);
+                }
+                out
+            }
+        }
+        #[cfg(not(atomic_maybe_uninit_no_ldex_stex))]
+        impl AtomicCompareExchange for $ty {
+            #[inline]
+            unsafe fn atomic_compare_exchange(
+                dst: *mut MaybeUninit<Self>,
+                old: MaybeUninit<Self>,
+                new: MaybeUninit<Self>,
+                success: Ordering,
+                failure: Ordering,
+            ) -> (MaybeUninit<Self>, bool) {
+                let order = crate::utils::upgrade_success_ordering(success, failure);
+                let (dst, shift, mask) = crate::utils::create_sub_word_mask_values(dst);
+                let mut out: MaybeUninit<Self>;
+
+                // SAFETY: the caller must uphold the safety contract.
+                unsafe {
+                    let mut r: u32;
+                    macro_rules! cmpxchg {
+                        ($acquire:tt, $release:tt) => {
+                            // Implement sub-word atomic operations using word-sized LL/SC loop.
+                            // See also create_sub_word_mask_values.
+                            asm!(
+                                "lsl32 {old}, {old}, {shift}",     // old <<= shift
+                                "lsl32 {new}, {new}, {shift}",     // new <<= shift
+                                $release,                          // fence
+                                "2:", // 'retry:
+                                    "ldex32.w {tmp}, ({dst}, 0)",  // atomic { tmp = *dst; EXCLUSIVE = dst }
+                                    "and32 {out}, {tmp}, {mask}",  // out = tmp & mask
+                                    "cmpne32 {out}, {old}",        // if out != old { C = 1 } else { C = 0 }
+                                    "bt32 3f",                     // if C == 1 { jump 'cmp-fail }
+                                    "andn32 {tmp}, {tmp}, {mask}", // tmp &= !mask
+                                    "or32 {tmp}, {tmp}, {new}",    // tmp |= new
+                                    "stex32.w {tmp}, ({dst}, 0)",  // atomic { if EXCLUSIVE == dst { *dst = tmp; tmp = 1 } else { tmp = 0 }; EXCLUSIVE = None }
+                                    "bez32 {tmp}, 2b",             // if tmp == 0 { jump 'retry }
+                                    "br32 4f",                     // jump 'success
+                                "3:", // 'cmp-fail:
+                                    "movi32 {tmp}, 0",             // tmp = 0
+                                "4:", // 'success:
+                                $acquire,                          // fence
+                                "lsr32 {out}, {out}, {shift}",     // out >>= shift
+                                dst = in(reg) ptr_reg!(dst),
+                                old = inout(reg) crate::utils::zero_extend32::$ty(old) => _,
+                                new = inout(reg) crate::utils::zero_extend32::$ty(new) => _,
+                                out = out(reg) out,
+                                shift = in(reg) shift,
+                                mask = in(reg) mask,
+                                tmp = out(reg) r,
+                                // Do not use `preserves_flags` because CMPNE modifies condition bit C.
+                                options(nostack),
+                            )
+                        };
+                    }
+                    atomic_rmw!(cmpxchg, order);
+                    crate::utils::assert_unchecked(r == 0 || r == 1); // may help remove extra test
+                    (out, r != 0)
+                }
+            }
+        }
+    };
+}
+
+atomic_sub_word!(u8, "b");
+atomic_sub_word!(u16, "h");
+atomic!(u32);
+
+// -----------------------------------------------------------------------------
+// cfg macros
+
+#[macro_export]
+macro_rules! cfg_has_atomic_8 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_8 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_16 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_16 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_32 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_32 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_64 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_64 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[macro_export]
+macro_rules! cfg_has_atomic_128 {
+    ($($tt:tt)*) => {};
+}
+#[macro_export]
+macro_rules! cfg_no_atomic_128 {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(not(atomic_maybe_uninit_no_ldex_stex))]
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}
+#[cfg(not(atomic_maybe_uninit_no_ldex_stex))]
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => {};
+}
+#[cfg(atomic_maybe_uninit_no_ldex_stex)]
+#[macro_export]
+macro_rules! cfg_has_atomic_cas {
+    ($($tt:tt)*) => {};
+}
+#[cfg(atomic_maybe_uninit_no_ldex_stex)]
+#[macro_export]
+macro_rules! cfg_no_atomic_cas {
+    ($($tt:tt)*) => { $($tt)* };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ This crate provides a way to soundly perform such operations.
 
 ## Platform Support
 
-Currently, x86, x86_64, Arm, AArch64, RISC-V, LoongArch, Arm64EC, s390x, MIPS, PowerPC, MSP430, AVR, SPARC, Hexagon, M68k, and Xtensa are supported.
+Currently, x86, x86_64, Arm, AArch64, RISC-V, LoongArch, Arm64EC, s390x, MIPS, PowerPC, MSP430, AVR, SPARC, Hexagon, M68k, C-SKY, and Xtensa are supported.
 (You can use `cfg_{has,no}_*` macros to write code based on whether or not which size of primitives is available.)
 
 | target_arch                     | primitives                                          | load/store | swap/CAS |
@@ -47,9 +47,10 @@ Currently, x86, x86_64, Arm, AArch64, RISC-V, LoongArch, Arm64EC, s390x, MIPS, P
 | hexagon \[9] (experimental)     | isize,usize,i8,u8,i16,u16,i32,u32,i64,u64           | ✓          | ✓        |
 | m68k \[9] (experimental)        | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          | ✓\[1]    |
 | m68k (+isa-68020) \[9] \[10] (experimental) | i64,u64                                 | ✓          | ✓        |
+| csky \[9] (experimental)        | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          | ✓\[1]    |
 | xtensa \[9] (experimental)      | isize,usize,i8,u8,i16,u16,i32,u32                   | ✓          | ✓\[1]    |
 
-\[1] Arm's atomic RMW operations are not available on Armv6-M (thumbv6m). RISC-V's atomic RMW operations are not available on targets without the A (or G which means IMAFD) or Zalrsc or Zacas extension, such as riscv32i, riscv32imc, etc. M68k's atomic RMW operations requires target-cpu M68020+ (enabled by default on Linux). Xtensa's atomic RMW operations are not available on esp32s2.<br>
+\[1] Arm's atomic RMW operations are not available on Armv6-M (thumbv6m). RISC-V's atomic RMW operations are not available on targets without the A (or G which means IMAFD) or Zalrsc or Zacas extension, such as riscv32i, riscv32imc, etc. M68k's atomic RMW operations requires target-cpu M68020+ (enabled by default on Linux). C-SKY's atomic RMW operations requires target-cpu ck860\* (enabled by default on the hard-float target). Xtensa's atomic RMW operations are not available on esp32s2.<br>
 \[2] Requires `cmpxchg16b` target feature (enabled by default on Apple, Windows (except Windows 7), and Fuchsia targets).<br>
 \[3] Armv6+ or Linux/Android, except for M-profile architecture such as thumbv6m, thumbv7m, etc.<br>
 \[4] Requires `zacas` target feature.<br>
@@ -857,6 +858,10 @@ pub use {cfg_has_atomic_128 as cfg_has_atomic_ptr, cfg_no_atomic_128 as cfg_no_a
 #[cfg_attr(
     all(target_arch = "avr", atomic_maybe_uninit_unstable_asm_experimental_arch),
     path = "arch/avr.rs"
+)]
+#[cfg_attr(
+    all(target_arch = "csky", atomic_maybe_uninit_unstable_asm_experimental_arch),
+    path = "arch/csky.rs"
 )]
 #[cfg_attr(
     all(target_arch = "hexagon", atomic_maybe_uninit_unstable_asm_experimental_arch),

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -69,6 +69,11 @@ default_targets=(
   # rustc -Z unstable-options --print all-target-specs-json | jq -r '. | to_entries[] | if .value.arch == "avr" then .key else empty end'
   avr-none
 
+  # csky
+  # rustc -Z unstable-options --print all-target-specs-json | jq -r '. | to_entries[] | if .value.arch == "csky" then .key else empty end'
+  csky-unknown-linux-gnuabiv2
+  csky-unknown-linux-gnuabiv2hf
+
   # hexagon
   # rustc -Z unstable-options --print all-target-specs-json | jq -r '. | to_entries[] | if .value.arch == "hexagon" then .key else empty end'
   # TODO(hexagon): error: symbol 'fma' is already defined
@@ -465,6 +470,11 @@ build() {
     avr*)
       CARGO_TARGET_DIR="${target_dir}/rmw" \
         RUSTFLAGS="${target_rustflags} -C target-feature=+rmw" \
+        x_cargo "${args[@]}" "$@"
+      ;;
+    csky-unknown-linux-gnuabiv2)
+      CARGO_TARGET_DIR="${target_dir}/ck860" \
+        RUSTFLAGS="${target_rustflags} -C target-cpu=ck860" \
         x_cargo "${args[@]}" "$@"
       ;;
   esac


### PR DESCRIPTION
Of the CPU architectures supported by Rust, this is the last architectures not supported by this crate.

~~The build passed, but has not yet been tested. The qemu binary mentioned on the platform support docs does not work with even a minimal program due to the following error:~~ UPDATE: See https://github.com/taiki-e/atomic-maybe-uninit/pull/32#issuecomment-3341287749

```
qemu: 0x00009ab4: unhandled CPU                 exception 0x4 - aborting
qemu:handle_cpu_signal received signal outside vCPU context @ pc=0x7f16efded943
```

~~TODO: ldex/stex is ck860* only? https://github.com/taiki-e/atomic-maybe-uninit/pull/32#issuecomment-3341287749~~ UPDATE: See https://github.com/taiki-e/atomic-maybe-uninit/pull/32#issuecomment-3368155333